### PR TITLE
More hot fixes for Infura compatiblity

### DIFF
--- a/web3.nim
+++ b/web3.nim
@@ -1,4 +1,4 @@
-import macros, strutils, options, math, json, tables, uri
+import macros, strutils, options, math, json, tables, uri, strformat
 from os import DirSep
 import
   nimcrypto, stint, httputils, chronicles, chronos, json_rpc/rpcclient,
@@ -760,7 +760,7 @@ proc call*[T](c: ContractCall[T],
   cc.value = some(value)
   let response = strip0xPrefix:
     if blockNumber != high(uint64):
-      await c.web3.provider.eth_call(cc, blockNumber)
+      await c.web3.provider.eth_call(cc, &"0x{blockNumber:X}")
     else:
       await c.web3.provider.eth_call(cc, "latest")
 

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -1,4 +1,4 @@
-import json, options, stint, stew/byteutils, strutils
+import json, options, stint, stew/byteutils, strutils, strformat
 from json_rpc/rpcserver import expect
 import ethtypes, ethhexstrings
 
@@ -113,6 +113,6 @@ proc `%`*(x: FilterOptions): JsonNode =
 
 proc `%`*(x: RtBlockIdentifier): JsonNode =
   case x.kind
-  of bidNumber: %x.number
+  of bidNumber: %(&"0x{x.number:X}")
   of bidAlias: %x.alias
 


### PR DESCRIPTION
Infura doesn't like block numbers appearing as regular JavaScript literals in the JSON. It reports the following error:

```
{"code":-32602,"message":"invalid argument 0: hex string without 0x prefix"}
```

The solution is to hex-encode all block numbers.