### PR TITLE
feat: export generated contracts and methods

### DIFF
--- a/web3.nim
+++ b/web3.nim
@@ -342,7 +342,7 @@ macro contract*(cname: untyped, body: untyped): untyped =
     eventListener = ident "eventListener"
   result.add quote do:
     type
-      `cname` = object
+      `cname`* = object
 
   for obj in objects:
     case obj.kind:
@@ -387,7 +387,7 @@ macro contract*(cname: untyped, body: untyped): untyped =
 
         `encodedParams` &= `dataBuf`
       var procDef = quote do:
-        proc `procName`(`senderName`: Sender[`cname`]): ContractCall[`output`] =
+        proc `procName`*(`senderName`: Sender[`cname`]): ContractCall[`output`] =
           discard
       for input in obj.functionObject.inputs:
         procDef[3].add nnkIdentDefs.newTree(


### PR DESCRIPTION
Previously, generated contract types and supporting methods were not exported and could not be used outside of the module declaring the contract without explicitly exporting each contract type and method. This PR exports the contract type definition and all contract methods.