### PR TITLE
Fix signature of eth_sign

### DIFF
--- a/web3/ethcallsigs.nim
+++ b/web3/ethcallsigs.nim
@@ -24,7 +24,7 @@ proc eth_getBlockTransactionCountByNumber(blockId: BlockIdentifier)
 proc eth_getUncleCountByBlockHash(data: BlockHash)
 proc eth_getUncleCountByBlockNumber(blockId: BlockIdentifier)
 proc eth_getCode(data: Address, blockId: BlockIdentifier): seq[byte]
-proc eth_sign(data: Address, message: seq[byte]): seq[byte]
+proc eth_sign(address: Address, data: string): seq[byte]
 proc eth_sendTransaction(obj: EthSend): TxHash
 proc eth_sendRawTransaction(data: string): TxHash
 proc eth_call(call: EthCall, blockId: BlockIdentifier): string #UInt256


### PR DESCRIPTION
Message to sign should be sent as a DATA hex string, not a JSON array of numbers.

Before this change, calling web3.provider.eth_sign would cause the following error in Ganache:
```
eth_sign

  Errors encountered in param 1: Invalid value [16,42,44,179,215,214,129,238,17,235,124,244,129,235,30,58,104,127,165,149,111,61,132,239,253,29,124,22,224,54,159,115] supplied to : DATA
```

See also: https://eth.wiki/json-rpc/API#eth_sign