### PR TITLE
enforce JSON-RPC Quantity spec syntax rules

### DIFF
--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,5 +1,5 @@
 # web3
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license: [LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT
 #   * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -10,6 +10,7 @@
 import
   test,
   test_deposit_contract,
+  test_ethhexstrings,
   test_logs,
-  test_signed_tx,
-  test_ethhexstrings
+  test_quantity,
+  test_signed_tx

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -82,11 +82,10 @@ const MetaCoinCode = "608060405234801561001057600080fd5b503260009081526020819052
 
 
 suite "Contracts":
-
-  var web3: Web3
-  var accounts: seq[Address]
-
   setup:
+    var web3: Web3
+    var accounts: seq[Address]
+
     proc asyncsetup {.async.} =
       web3 = await newWeb3("ws://127.0.0.1:8545/")
       accounts = await web3.provider.eth_accounts()

--- a/tests/test_quantity.nim
+++ b/tests/test_quantity.nim
@@ -1,0 +1,41 @@
+import
+  unittest, std/json,
+  stint,
+  ../web3/[conversions, ethtypes]
+
+proc `==`(x, y: Quantity): bool {.borrow, noSideEffect.}
+
+suite "JSON-RPC Quantity":
+  test "Valid":
+    for (validQuantityStr, validQuantity) in [
+        ("0x0", 0),
+        ("0x123", 291),
+        ("0x1234", 4660)]:
+      var resQuantity: Quantity
+      var resUInt256: UInt256
+      var resUInt256Ref: ref UInt256
+      fromJson(%validQuantityStr, "", resQuantity)
+      fromJson(%validQuantityStr, "", resUInt256)
+      fromJson(%validQuantityStr, "", resUInt256Ref)
+      check:
+        resQuantity == validQuantity.Quantity
+        resUInt256 == validQuantity.u256
+        resUInt256Ref[] == validQuantity.u256
+
+  test "Invalid Quantity/UInt256/ref UInt256":
+    for invalidStr in [
+        "", "1234", "01234", "x1234", "0x", "0x0400", "ff"]:
+      template checkInvalids(typeName: untyped) =
+        var resQuantity: `typeName`
+        try:
+          fromJson(%invalidStr, "", resQuantity)
+          echo `typeName`, invalidStr
+          check: false
+        except ValueError:
+          check: true
+        except CatchableError:
+          check: false
+
+      checkInvalids(Quantity)
+      checkInvalids(UInt256)
+      checkInvalids(ref UInt256)

--- a/tests/test_utils.nim
+++ b/tests/test_utils.nim
@@ -17,5 +17,5 @@ proc deployContract*(web3: Web3, code: string, gasPrice = 0): Future[ReceiptObje
   let r = await web3.send(tr)
   return await web3.getMinedTransactionReceipt(r)
 
-proc ethToWei*(eth: UInt256): UInt256 =
+func ethToWei*(eth: UInt256): UInt256 =
   eth * 1000000000000000000.u256

--- a/web3/confutils_defs.nim
+++ b/web3/confutils_defs.nim
@@ -6,12 +6,11 @@ func parseCmdArg*(T: type Address, input: TaintedString): T
   fromHex(T, string input)
 
 func completeCmdArg*(T: type Address, input: TaintedString): seq[string] =
-  return @[]
+  @[]
 
 func parseCmdArg*(T: type BlockHash, input: TaintedString): T
                  {.raises: [ValueError, Defect].} =
   fromHex(T, string input)
 
 func completeCmdArg*(T: type BlockHash, input: TaintedString): seq[string] =
-  return @[]
-
+  @[]

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -1,3 +1,9 @@
+# Copyright (c) 2019-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[json, options, strutils, strformat, tables, typetraits],
   stint, stew/byteutils, json_serialization, faststreams/textio,
@@ -6,47 +12,65 @@ import
 
 from json_rpc/rpcserver import expect
 
-proc `%`*(n: Int256|UInt256): JsonNode = %("0x" & n.toHex)
+template invalidQuantityPrefix(s: string): bool =
+  # https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-value-encoding
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#structures
+  # "When encoding quantities (integers, numbers): encode as hex, prefix with
+  # "0x", the most compact representation (slight exception: zero should be
+  # represented as "0x0")."
+  #
+  # strutils.parseHexStr treats 0x as optional otherwise. UInt256.parse treats
+  # standalone "0x" as valid input.
+  (not s.startsWith "0x") or s == "0x" or (s != "0x0" and s.startsWith "0x0")
+
+func `%`*(n: Int256|UInt256): JsonNode = %("0x" & n.toHex)
 
 # allows UInt256 to be passed as a json string
-proc fromJson*(n: JsonNode, argName: string, result: var UInt256) =
+func fromJson*(n: JsonNode, argName: string, result: var UInt256) =
   # expects base 16 string, starting with "0x"
   n.kind.expect(JString, argName)
   let hexStr = n.getStr()
   if hexStr.len > 64 + 2: # including "0x"
     raise newException(ValueError, "Parameter \"" & argName & "\" value too long for UInt256: " & $hexStr.len)
+  if hexStr.invalidQuantityPrefix:
+    raise newException(ValueError, "Parameter \"" & argName & "\" value has invalid leading 0")
   result = hexStr.parse(StUint[256], 16) # TODO: Handle errors
 
 # allows ref UInt256 to be passed as a json string
-proc fromJson*(n: JsonNode, argName: string, result: var ref UInt256) =
+func fromJson*(n: JsonNode, argName: string, result: var ref UInt256) =
   # expects base 16 string, starting with "0x"
   n.kind.expect(JString, argName)
   let hexStr = n.getStr()
   if hexStr.len > 64 + 2: # including "0x"
     raise newException(ValueError, "Parameter \"" & argName & "\" value too long for UInt256: " & $hexStr.len)
+  if hexStr.invalidQuantityPrefix:
+    raise newException(ValueError, "Parameter \"" & argName & "\" value has invalid leading 0")
   new result
   result[] = hexStr.parse(StUint[256], 16) # TODO: Handle errors
 
-proc bytesFromJson(n: JsonNode, argName: string, result: var openArray[byte]) =
+func bytesFromJson(n: JsonNode, argName: string, result: var openArray[byte]) =
   n.kind.expect(JString, argName)
   let hexStr = n.getStr()
   if hexStr.len != result.len * 2 + 2: # including "0x"
     raise newException(ValueError, "Parameter \"" & argName & "\" value wrong length: " & $hexStr.len)
   hexToByteArray(hexStr, result)
 
-proc fromJson*[N](n: JsonNode, argName: string, result: var FixedBytes[N]) {.inline.} =
+func fromJson*[N](n: JsonNode, argName: string, result: var FixedBytes[N])
+    {.inline.} =
   # expects base 16 string, starting with "0x"
   bytesFromJson(n, argName, array[N, byte](result))
 
-proc fromJson*(n: JsonNode, argName: string, result: var DynamicBytes) {.inline.} =
+func fromJson*(n: JsonNode, argName: string, result: var DynamicBytes)
+    {.inline.} =
   n.kind.expect(JString, argName)
   result = fromHex(type result, n.getStr())
 
-proc fromJson*(n: JsonNode, argName: string, result: var Address) {.inline.} =
+func fromJson*(n: JsonNode, argName: string, result: var Address) {.inline.} =
   # expects base 16 string, starting with "0x"
   bytesFromJson(n, argName, array[20, byte](result))
 
-proc fromJson*(n: JsonNode, argName: string, result: var TypedTransaction) {.inline.} =
+func fromJson*(n: JsonNode, argName: string, result: var TypedTransaction)
+    {.inline.} =
   let hexStrLen = n.getStr().len
   if hexStrLen < 2:
     # "0x" prefix
@@ -58,14 +82,15 @@ proc fromJson*(n: JsonNode, argName: string, result: var TypedTransaction) {.inl
   distinctBase(result).setLen((hexStrLen - 2) div 2)
   bytesFromJson(n, argName, distinctBase(result))
 
-proc fromJson*(n: JsonNode, argName: string, result: var Quantity) {.inline.} =
-  if n.kind == JInt:
-    result = Quantity(n.getBiggestInt)
-  else:
-    n.kind.expect(JString, argName)
-    result = Quantity(parseHexInt(n.getStr))
+func fromJson*(n: JsonNode, argName: string, result: var Quantity) {.inline.} =
+  n.kind.expect(JString, argName)
+  let hexStr = n.getStr
+  if hexStr.invalidQuantityPrefix:
+    raise newException(ValueError, "Parameter \"" & argName & "\" value has invalid leading 0")
+  result = Quantity(parseHexInt(hexStr))
 
-func getEnumStringTable(enumType: typedesc): Table[string, enumType] {.compileTime.} =
+func getEnumStringTable(enumType: typedesc): Table[string, enumType]
+    {.compileTime.} =
   var res: Table[string, enumType]
   # Not intended for enums with ordinal holes or repeated stringification
   # strings.
@@ -73,8 +98,9 @@ func getEnumStringTable(enumType: typedesc): Table[string, enumType] {.compileTi
     res[$value] = value
   res
 
-proc fromJson*(
-    n: JsonNode, argName: string, result: var PayloadExecutionStatus) {.inline.} =
+func fromJson*(
+    n: JsonNode, argName: string, result: var PayloadExecutionStatus)
+    {.inline.} =
   n.kind.expect(JString, argName)
   const enumStrings = static: getEnumStringTable(type(result))
   try:
@@ -83,20 +109,20 @@ proc fromJson*(
     raise newException(
       ValueError, "Parameter \"" & argName & "\" value invalid: " & n.getStr)
 
-proc `%`*(v: Quantity): JsonNode =
-  result = %encodeQuantity(v.uint64)
+func `%`*(v: Quantity): JsonNode =
+  %encodeQuantity(v.uint64)
 
-proc `%`*[N](v: FixedBytes[N]): JsonNode =
-  result = %("0x" & array[N, byte](v).toHex)
+func `%`*[N](v: FixedBytes[N]): JsonNode =
+  %("0x" & array[N, byte](v).toHex)
 
-proc `%`*(v: DynamicBytes): JsonNode =
-  result = %("0x" & toHex(v))
+func `%`*(v: DynamicBytes): JsonNode =
+  %("0x" & toHex(v))
 
-proc `%`*(v: Address): JsonNode =
-  result = %("0x" & array[20, byte](v).toHex)
+func `%`*(v: Address): JsonNode =
+  %("0x" & array[20, byte](v).toHex)
 
-proc `%`*(v: TypedTransaction): JsonNode =
-  result = %("0x" & distinctBase(v).toHex)
+func `%`*(v: TypedTransaction): JsonNode =
+  %("0x" & distinctBase(v).toHex)
 
 proc writeHexValue(w: JsonWriter, v: openArray[byte]) =
   w.stream.write "\"0x"
@@ -127,19 +153,19 @@ proc readValue*(r: var JsonReader, T: type Address): T =
 proc readValue*(r: var JsonReader, T: type TypedTransaction): T =
   T fromHex(seq[byte], r.readValue(string))
 
-proc `$`*[N](v: FixedBytes[N]): string {.inline.} =
+func `$`*[N](v: FixedBytes[N]): string {.inline.} =
   "0x" & array[N, byte](v).toHex
 
-proc `$`*(v: Address): string {.inline.} =
+func `$`*(v: Address): string {.inline.} =
   "0x" & array[20, byte](v).toHex
 
-proc `$`*(v: TypedTransaction): string {.inline.} =
+func `$`*(v: TypedTransaction): string {.inline.} =
   "0x" & distinctBase(v).toHex
 
-proc `$`*(v: DynamicBytes): string {.inline.} =
+func `$`*(v: DynamicBytes): string {.inline.} =
   "0x" & toHex(v)
 
-proc `%`*(x: EthSend): JsonNode =
+func `%`*(x: EthSend): JsonNode =
   result = newJObject()
   result["from"] = %x.source
   if x.to.isSome:
@@ -155,7 +181,7 @@ proc `%`*(x: EthSend): JsonNode =
   if x.nonce.isSome:
     result["nonce"] = %x.nonce.unsafeGet
 
-proc `%`*(x: EthCall): JsonNode =
+func `%`*(x: EthCall): JsonNode =
   result = newJObject()
   result["to"] = %x.to
   if x.source.isSome:
@@ -169,10 +195,10 @@ proc `%`*(x: EthCall): JsonNode =
   if x.data.isSome:
     result["data"] = %x.data.unsafeGet
 
-proc `%`*(x: byte): JsonNode =
+func `%`*(x: byte): JsonNode =
   %x.int
 
-proc `%`*(x: FilterOptions): JsonNode =
+func `%`*(x: FilterOptions): JsonNode =
   result = newJObject()
   if x.fromBlock.isSome:
     result["fromBlock"] = %x.fromBlock.unsafeGet
@@ -183,8 +209,7 @@ proc `%`*(x: FilterOptions): JsonNode =
   if x.topics.isSome:
     result["topics"] = %x.topics.unsafeGet
 
-proc `%`*(x: RtBlockIdentifier): JsonNode =
+func `%`*(x: RtBlockIdentifier): JsonNode =
   case x.kind
   of bidNumber: %(&"0x{x.number:X}")
   of bidAlias: %x.alias
-

--- a/web3/encoding.nim
+++ b/web3/encoding.nim
@@ -152,11 +152,11 @@ macro makeTypeEnum(): untyped =
 
 makeTypeEnum()
 
-proc parse*(T: type Bool, val: bool): T =
+func parse*(T: type Bool, val: bool): T =
   let i = if val: 1 else: 0
   T i.i256
 
-proc `==`*(a: Bool, b: Bool): bool =
+func `==`*(a: Bool, b: Bool): bool =
   Int256(a) == Int256(b)
 
 func encode*(x: Bool): EncodeResult = encode(Int256(x))

--- a/web3/engine_api.nim
+++ b/web3/engine_api.nim
@@ -11,4 +11,3 @@ from os import DirSep, AltSep
 template sourceDir: string = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
 
 createRpcSigs(RpcClient, sourceDir & "/engine_api_callsigs.nim")
-

--- a/web3/ethhexstrings.nim
+++ b/web3/ethhexstrings.nim
@@ -1,4 +1,4 @@
-import strutils
+import std/strutils
 
 type
   HexQuantityStr* = distinct string
@@ -13,7 +13,7 @@ template stripLeadingZeros(value: string): string =
     cidx.inc
   value[cidx .. ^1]
 
-proc encodeQuantity*(value: SomeUnsignedInt): string =
+func encodeQuantity*(value: SomeUnsignedInt): string =
   var hValue = value.toHex.stripLeadingZeros
   result = "0x" & hValue
 
@@ -30,7 +30,7 @@ func isHexChar*(c: char): bool =
       c notin {'A'..'F'}: false
   else: true
 
-proc validate*(value: HexQuantityStr): bool =
+func validate*(value: HexQuantityStr): bool =
   template strVal: untyped = value.string
   if not value.hasHexHeader:
     return false
@@ -42,7 +42,7 @@ proc validate*(value: HexQuantityStr): bool =
       return false
   return true
 
-proc validate*(value: HexDataStr): bool =
+func validate*(value: HexDataStr): bool =
   template strVal: untyped = value.string
   if not value.hasHexHeader:
     return false
@@ -62,22 +62,22 @@ template hexQuantityStr*(value: string): HexQuantityStr = value.HexQuantityStr
 
 # Converters
 
-import json
+import std/json
 from json_rpc/rpcserver import expect
 
-proc `%`*(value: HexDataStr): JsonNode =
+func `%`*(value: HexDataStr): JsonNode =
   if not value.validate:
     raise newException(ValueError, "HexDataStr: Invalid hex for Ethereum: " & value.string)
   else:
     result = %(value.string)
 
-proc `%`*(value: HexQuantityStr): JsonNode =
+func `%`*(value: HexQuantityStr): JsonNode =
   if not value.validate:
     raise newException(ValueError, "HexQuantityStr: Invalid hex for Ethereum: " & value.string)
   else:
     result = %(value.string)
 
-proc fromJson*(n: JsonNode, argName: string, result: var HexDataStr) =
+func fromJson*(n: JsonNode, argName: string, result: var HexDataStr) =
   # Note that '0x' is stripped after validation
   n.kind.expect(JString, argName)
   let hexStr = n.getStr()
@@ -85,11 +85,10 @@ proc fromJson*(n: JsonNode, argName: string, result: var HexDataStr) =
     raise newException(ValueError, "Parameter \"" & argName & "\" value is not valid as a Ethereum data \"" & hexStr & "\"")
   result = hexStr[2..hexStr.high].hexDataStr
 
-proc fromJson*(n: JsonNode, argName: string, result: var HexQuantityStr) =
+func fromJson*(n: JsonNode, argName: string, result: var HexQuantityStr) =
   # Note that '0x' is stripped after validation
   n.kind.expect(JString, argName)
   let hexStr = n.getStr()
   if not hexStr.hexQuantityStr.validate:
     raise newException(ValueError, "Parameter \"" & argName & "\" value is not valid as an Ethereum hex quantity \"" & hexStr & "\"")
   result = hexStr[2..hexStr.high].hexQuantityStr
-

--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -226,7 +226,7 @@ template `==`*[N](a, b: FixedBytes[N]): bool =
 template `==`*[minLen, maxLen](a, b: DynamicBytes[minLen, maxLen]): bool =
   distinctBase(a) == distinctBase(b)
 
-proc `==`*(a, b: Address): bool {.inline.} =
+func `==`*(a, b: Address): bool {.inline.} =
   array[20, byte](a) == array[20, byte](b)
 
 func blockId*(n: BlockNumber): RtBlockIdentifier =
@@ -259,7 +259,7 @@ template skip0xPrefix(hexStr: string): int =
   if hexStr.len > 1 and hexStr[0] == '0' and hexStr[1] in {'x', 'X'}: 2
   else: 0
 
-proc strip0xPrefix*(s: string): string =
+func strip0xPrefix*(s: string): string =
   let prefixLen = skip0xPrefix(s)
   if prefixLen != 0:
     s[prefixLen .. ^1]
@@ -281,7 +281,7 @@ func fromHex*[minLen, maxLen](T: type DynamicBytes[minLen, maxLen], hexStr: stri
 template fromHex*[N](T: type FixedBytes[N], hexStr: string): T =
   T fromHex(distinctBase(T), hexStr)
 
-proc toArray*[N](data: DynamicBytes[N, N]): array[N, byte] =
+func toArray*[N](data: DynamicBytes[N, N]): array[N, byte] =
   copyMem(addr result[0], unsafeAddr distinctBase(data)[0], N)
 
 template bytes*(data: DynamicBytes): seq[byte] =

--- a/web3/transaction_signing.nim
+++ b/web3/transaction_signing.nim
@@ -3,7 +3,7 @@ import
   ethtypes, stew/byteutils, stint,
   eth/[common, keys, rlp], eth/common/transaction
 
-proc signTransaction(tr: var Transaction, pk: PrivateKey) =
+func signTransaction(tr: var Transaction, pk: PrivateKey) =
   let h = tr.txHashNoSignature
   let s = sign(pk, SkMessage(h.data))
 
@@ -15,7 +15,7 @@ proc signTransaction(tr: var Transaction, pk: PrivateKey) =
 
   tr.V = int64(v) + 27 # TODO! Complete this
 
-proc encodeTransaction*(s: EthSend, pk: PrivateKey): string =
+func encodeTransaction*(s: EthSend, pk: PrivateKey): string =
   var tr = Transaction(txType: TxLegacy)
   tr.gasLimit = GasInt(s.gas.get.uint64)
   tr.gasPrice = s.gasPrice.get


### PR DESCRIPTION
- `proc` to `func`
- remove some `result` usage
- add tests for `Quantity` parsing
- address https://github.com/status-im/nimbus-eth2/issues/3844