### PR TITLE
Add client for eth_getProof

### DIFF
--- a/tests/test_ethhexstrings.nim
+++ b/tests/test_ethhexstrings.nim
@@ -35,6 +35,11 @@ suite "Hex quantity":
         source = "x1234"
         x = hexQuantityStr source
       check %x != %source
+  test "Hex encoded 0x0":
+    let
+      source = "0x0"
+      x = hexQuantityStr"0x0"
+    check %x == %source
 
 suite "Hex data":
   test "Even length":

--- a/web3/ethcallsigs.nim
+++ b/web3/ethcallsigs.nim
@@ -58,6 +58,11 @@ proc eth_subscribe(name: string, options: JsonNode): string
 proc eth_subscribe(name: string): string
 proc eth_unsubscribe(id: string)
 
+proc eth_getProof(
+  address: Address,
+  slots: seq[UInt256],
+  blockId: BlockIdentifier): ProofResponse
+
 proc shh_post(): string
 proc shh_version(message: WhisperPost): bool
 proc shh_newIdentity(): array[60, byte]

--- a/web3/ethhexstrings.nim
+++ b/web3/ethhexstrings.nim
@@ -34,8 +34,8 @@ func validate*(value: HexQuantityStr): bool =
   template strVal: untyped = value.string
   if not value.hasHexHeader:
     return false
-  # No leading zeros
-  if strVal[2] == '0': return false
+  # No leading zeros (but allow 0x0)
+  if strVal.len < 3 or (strVal.len > 3 and strVal[2] == '0'): return false
   for i in 2..<strVal.len:
     let c = strVal[i]
     if not c.isHexChar:

--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -19,6 +19,8 @@ type
   BlockNumber* = uint64
   BlockIdentifier* = string|BlockNumber|RtBlockIdentifier
   Nonce* = int
+  CodeHash* = FixedBytes[32]
+  StorageHash* = FixedBytes[32]
 
   BlockIdentifierKind* = enum
     bidNumber
@@ -219,6 +221,22 @@ type
     baseFeePerGas*: UInt256
     blockHash*: BlockHash
     transactions*: seq[TypedTransaction]
+
+  RlpEncodedBytes* = distinct seq[byte]
+
+  StorageProof* = object
+    key*: UInt256
+    value*: UInt256
+    proof*: seq[RlpEncodedBytes]
+
+  ProofResponse* = object
+    address*: Address
+    accountProof*: seq[RlpEncodedBytes]
+    balance*: UInt256
+    codeHash*: CodeHash
+    nonce*: Quantity
+    storageHash*: StorageHash
+    storageProof*: seq[StorageProof]
 
 template `==`*[N](a, b: FixedBytes[N]): bool =
   distinctBase(a) == distinctBase(b)


### PR DESCRIPTION
- Add `get_Proof` client call (https://eips.ethereum.org/EIPS/eip-1186)
- Fixes bug in `hexstrings` which did not allow `0x0` hex.