### PR TITLE
add encode proc for string

### DIFF
--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -13,4 +13,5 @@ import
   test_ethhexstrings,
   test_logs,
   test_quantity,
-  test_signed_tx
+  test_signed_tx,
+  test_abi

--- a/tests/test_abi.nim
+++ b/tests/test_abi.nim
@@ -1,0 +1,4 @@
+import ../web3
+
+contract(String): # string as input parameters
+  proc foo(input: string)

--- a/web3/encoding.nim
+++ b/web3/encoding.nim
@@ -65,6 +65,9 @@ func encodeDynamic(v: openArray[byte]): EncodeResult =
 func encode*(x: DynamicBytes): EncodeResult {.inline.} =
   encodeDynamic(distinctBase x)
 
+func encode*(x: string): EncodeResult {.inline.} =
+  encodeDynamic(toOpenArrayByte(x, 0, x.high))
+
 func decode*(input: string, offset: int, to: var DynamicBytes): int {.inline.} =
   var dataOffset, dataLen: UInt256
   result = decode(input, offset, dataOffset)


### PR DESCRIPTION
According to https://docs.soliditylang.org/en/v0.8.17/abi-spec.html

> string:

> enc(X) = enc(enc_utf8(X)), i.e. X is UTF-8 encoded and this value is interpreted as of bytes type and encoded further. Note that the length used in this subsequent encoding is the number of bytes of the UTF-8 encoded string, not its number of characters.

A Nim string should be converted to a byte sequence and call `encodeDynamic` in order to get the correct encoding.