### PR TITLE
Handle empty data hex string

### DIFF
--- a/tests/test_ethhexstrings.nim
+++ b/tests/test_ethhexstrings.nim
@@ -47,6 +47,11 @@ suite "Hex data":
       source = "0x1234"
       x = hexDataStr source
     check %x == %source
+  test "Empty data":
+    let
+      source = "0x"
+      x = hexDataStr source
+    check %x == %source
   test "Odd length":
     expect ValueError:
       let

--- a/web3/ethhexstrings.nim
+++ b/web3/ethhexstrings.nim
@@ -23,8 +23,7 @@ func encodeQuantity*(value: SomeUnsignedInt): string =
   result = "0x" & hValue
 
 func hasHexHeader*(value: string): bool =
-  if value != "" and value[0] == '0' and value[1] in {'x', 'X'} and value.len > 2: true
-  else: false
+  value.len >= 2 and value[0] == '0' and value[1] in {'x', 'X'}
 
 template hasHexHeader*(value: HexDataStr|HexQuantityStr): bool =
   value.string.hasHexHeader


### PR DESCRIPTION
It should be possible to have empty hex data string, for exemple when returning response for `eth_getCode` request for user controlled account