### PR TITLE
remove `gnosisChainBinary` hack

### DIFF
--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -92,9 +92,8 @@ type
     gasLimit*: Quantity
     gasUsed*: Quantity
     timestamp*: Quantity
-    when not defined(gnosisChainBinary):
-      nonce*: FixedBytes[8]
-      mixHash*: BlockHash
+    nonce*: FixedBytes[8]
+    mixHash*: BlockHash
 
   ## A block object, or null when no block was found
   BlockObject* = ref object


### PR DESCRIPTION
It appears gnosis publishes both nonce and mixhash these days, looking
at `curl https://rpc.gnosischain.com/   -X POST   -H "Content-Type:
application/json"   --data
'{"method":"eth_getBlockByNumber","params":["0x18c97c0",false],"id":1,"jsonrpc":"2.0"}'
| jq`