### PR TITLE
re-add GetPayload v2 return type actually constrained to v2

### DIFF
--- a/web3/engine_api.nim
+++ b/web3/engine_api.nim
@@ -38,6 +38,12 @@ template getPayload*(
 
 template getPayload*(
     rpcClient: RpcClient,
+    T: type GetPayloadV2ResponseExact,
+    payloadId: PayloadID): Future[GetPayloadV2ResponseExact] =
+  engine_getPayloadV2(rpcClient, payloadId)
+
+template getPayload*(
+    rpcClient: RpcClient,
     T: type GetPayloadV3Response,
     payloadId: PayloadID): Future[GetPayloadV3Response] =
   engine_getPayloadV3(rpcClient, payloadId)

--- a/web3/engine_api.nim
+++ b/web3/engine_api.nim
@@ -40,7 +40,7 @@ template getPayload*(
     rpcClient: RpcClient,
     T: type GetPayloadV2ResponseExact,
     payloadId: PayloadID): Future[GetPayloadV2ResponseExact] =
-  engine_getPayloadV2(rpcClient, payloadId)
+  engine_getPayloadV2_exact(rpcClient, payloadId)
 
 template getPayload*(
     rpcClient: RpcClient,

--- a/web3/engine_api_callsigs.nim
+++ b/web3/engine_api_callsigs.nim
@@ -10,6 +10,7 @@ proc engine_forkchoiceUpdatedV1(forkchoiceState: ForkchoiceStateV1, payloadAttri
 proc engine_forkchoiceUpdatedV2(forkchoiceState: ForkchoiceStateV1, payloadAttributes: Option[PayloadAttributesV2]): ForkchoiceUpdatedResponse
 proc engine_getPayloadV1(payloadId: PayloadID): ExecutionPayloadV1
 proc engine_getPayloadV2(payloadId: PayloadID): GetPayloadV2Response
+proc engine_getPayloadV2_exact(payloadId: PayloadID): GetPayloadV2ResponseExact
 proc engine_getPayloadV3(payloadId: PayloadID): GetPayloadV3Response
 proc engine_exchangeTransitionConfigurationV1(transitionConfiguration: TransitionConfigurationV1): TransitionConfigurationV1
 proc engine_getBlobsBundleV1(payloadId: PayloadID): BlobsBundleV1

--- a/web3/engine_api_types.nim
+++ b/web3/engine_api_types.nim
@@ -69,6 +69,10 @@ type
     executionPayload*: ExecutionPayloadV1OrV2
     blockValue*: UInt256
 
+  GetPayloadV2ResponseExact* = object
+    executionPayload*: ExecutionPayloadV2
+    blockValue*: UInt256
+
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/experimental/blob-extension.md#response-1
   GetPayloadV3Response* = object
     executionPayload*: ExecutionPayloadV3
@@ -81,7 +85,7 @@ type
 
 const
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/common.md#errors
-  engineApiParseError* = - 32700
+  engineApiParseError* = -32700
   engineApiInvalidRequest* = -32600
   engineApiMethodNotFound* = -32601
   engineApiInvalidParams* = -32602


### PR DESCRIPTION
A follow-up of sorts to https://github.com/status-im/nim-web3/pull/77

It might be that `nimbus-eth1` indeed requires a signature for this `getPayloadV2` call which has this ambiguous return value. `nimbus-eth2` does not require or benefit from such a call.

Therefore, it's reasonable to have both. Whatever other cleanups or modifications occur, it will remain useful for `nimbus-eth2` to be able to call this RPC and use the RPC framework to validate the exact payload type it's expecting, rather than having to do so ad-hoc separately.