### PR TITLE
fix `TransactionObject` type up through mainnet

### DIFF
--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -178,6 +178,7 @@ type
     `type`*: Option[Quantity]               # EIP-2718, with 0x0 for Legacy
     chainId*: Option[UInt256]               # EIP-159
     accessList*: Option[seq[AccessTuple]]   # EIP-2930
+    maxFeePerGas*: Option[Quantity]         # EIP-1559
     maxPriorityFeePerGas*: Option[Quantity] # EIP-1559
 
   ReceiptKind* = enum rkRoot, rkStatus

--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -168,13 +168,13 @@ type
     transactionIndex*: Option[Quantity]     # integer of the transactions index position in the block. null when its pending.
     `from`*: Address                        # address of the sender.
     to*: Option[Address]                    # address of the receiver. null when its a contract creation transaction.
-    value*: Quantity                        # value transferred in Wei.
+    value*: UInt256                         # value transferred in Wei.
     gasPrice*: Quantity                     # gas price provided by the sender in Wei.
     gas*: Quantity                          # gas provided by the sender.
     input*: seq[byte]                       # the data send along with the transaction.
-    v*: Quantity                            # ECDSA recovery id
-    r*: Quantity                            # ECDSA signature r
-    s*: Quantity                            # ECDSA signature s
+    v*: UInt256                             # ECDSA recovery id
+    r*: UInt256                             # ECDSA signature r
+    s*: UInt256                             # ECDSA signature s
     `type`*: Option[Quantity]               # EIP-2718, with 0x0 for Legacy
     chainId*: Option[UInt256]               # EIP-159
     accessList*: Option[seq[AccessTuple]]   # EIP-2930

--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -160,25 +160,25 @@ type
     address*: Address
     storageKeys*: seq[Hash256]
 
-  TransactionObject* = object              # A transaction object, or null when no transaction was found:
-    hash*: TxHash                          # hash of the transaction.
-    nonce*: Quantity                       # TODO: Is int? the number of transactions made by the sender prior to this one.
-    blockHash*: Option[BlockHash]          # hash of the block where this transaction was in. null when its pending.
-    blockNumber*: Option[Quantity]         # block number where this transaction was in. null when its pending.
-    transactionIndex*: Option[Quantity]    # integer of the transactions index position in the block. null when its pending.
-    `from`*: Address                       # address of the sender.
-    to*: Option[Address]                   # address of the receiver. null when its a contract creation transaction.
-    value*: Quantity                       # value transferred in Wei.
-    gasPrice*: Quantity                    # gas price provided by the sender in Wei.
-    gas*: Quantity                         # gas provided by the sender.
-    input*: seq[byte]                      # the data send along with the transaction.
-    v: Quantity                            # ECDSA recovery id
-    r: Quantity                            # ECDSA signature r
-    s: Quantity                            # ECDSA signature s
-    `type`*: Option[Quantity]              # EIP-2718, with 0x0 for Legacy
-    chainId: Option[UInt256]               # EIP-159
-    accessList: Option[seq[AccessTuple]]   # EIP-2930
-    maxPriorityFeePerGas: Option[Quantity] # EIP-1559
+  TransactionObject* = object               # A transaction object, or null when no transaction was found:
+    hash*: TxHash                           # hash of the transaction.
+    nonce*: Quantity                        # TODO: Is int? the number of transactions made by the sender prior to this one.
+    blockHash*: Option[BlockHash]           # hash of the block where this transaction was in. null when its pending.
+    blockNumber*: Option[Quantity]          # block number where this transaction was in. null when its pending.
+    transactionIndex*: Option[Quantity]     # integer of the transactions index position in the block. null when its pending.
+    `from`*: Address                        # address of the sender.
+    to*: Option[Address]                    # address of the receiver. null when its a contract creation transaction.
+    value*: Quantity                        # value transferred in Wei.
+    gasPrice*: Quantity                     # gas price provided by the sender in Wei.
+    gas*: Quantity                          # gas provided by the sender.
+    input*: seq[byte]                       # the data send along with the transaction.
+    v*: Quantity                            # ECDSA recovery id
+    r*: Quantity                            # ECDSA signature r
+    s*: Quantity                            # ECDSA signature s
+    `type`*: Option[Quantity]               # EIP-2718, with 0x0 for Legacy
+    chainId*: Option[UInt256]               # EIP-159
+    accessList*: Option[seq[AccessTuple]]   # EIP-2930
+    maxPriorityFeePerGas*: Option[Quantity] # EIP-1559
 
   ReceiptKind* = enum rkRoot, rkStatus
   ReceiptObject* = object

--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -156,18 +156,29 @@ type
     dataGasUsed*: Option[Quantity]              # EIP-4844
     excessDataGas*: Option[Quantity]            # EIP-4844
 
-  TransactionObject* = object     # A transaction object, or null when no transaction was found:
-    hash*: TxHash                 # hash of the transaction.
-    nonce*: int64                 # TODO: Is int? the number of transactions made by the sender prior to this one.
-    blockHash*: BlockHash         # hash of the block where this transaction was in. null when its pending.
-    blockNumber*: int64           # block number where this transaction was in. null when its pending.
-    transactionIndex*: int64      # integer of the transactions index position in the block. null when its pending.
-    source*: Address              # address of the sender.
-    to*: Address                  # address of the receiver. null when its a contract creation transaction.
-    value*: int64                 # value transferred in Wei.
-    gasPrice*: int64              # gas price provided by the sender in Wei.
-    gas*: Quantity                # gas provided by the sender.
-    input*: seq[byte]             # the data send along with the transaction.
+  AccessTuple* = object
+    address*: Address
+    storageKeys*: seq[Hash256]
+
+  TransactionObject* = object              # A transaction object, or null when no transaction was found:
+    hash*: TxHash                          # hash of the transaction.
+    nonce*: Quantity                       # TODO: Is int? the number of transactions made by the sender prior to this one.
+    blockHash*: Option[BlockHash]          # hash of the block where this transaction was in. null when its pending.
+    blockNumber*: Option[Quantity]         # block number where this transaction was in. null when its pending.
+    transactionIndex*: Option[Quantity]    # integer of the transactions index position in the block. null when its pending.
+    `from`*: Address                       # address of the sender.
+    to*: Option[Address]                   # address of the receiver. null when its a contract creation transaction.
+    value*: Quantity                       # value transferred in Wei.
+    gasPrice*: Quantity                    # gas price provided by the sender in Wei.
+    gas*: Quantity                         # gas provided by the sender.
+    input*: seq[byte]                      # the data send along with the transaction.
+    v: Quantity                            # ECDSA recovery id
+    r: Quantity                            # ECDSA signature r
+    s: Quantity                            # ECDSA signature s
+    `type`*: Option[Quantity]              # EIP-2718, with 0x0 for Legacy
+    chainId: Option[UInt256]               # EIP-159
+    accessList: Option[seq[AccessTuple]]   # EIP-2930
+    maxPriorityFeePerGas: Option[Quantity] # EIP-1559
 
   ReceiptKind* = enum rkRoot, rkStatus
   ReceiptObject* = object


### PR DESCRIPTION
Correct `TransactionObject` types to `Quantity`, `source` to `from`, and add missing fields for parsing JsonRPC up through EIP-1559. EIP-4844 still missing.