### PR TITLE
replace `{.raises: [Defect].}` with `{.raises: [].}` (Nim 1.6)

### DIFF
--- a/tests/test.nim
+++ b/tests/test.nim
@@ -148,7 +148,7 @@ suite "Contracts":
 
       let s = await ns.subscribe(Transfer) do (
           fromAddr, toAddr: Address, value: UInt256)
-          {.raises: [Defect], gcsafe.}:
+          {.raises: [], gcsafe.}:
         try:
           echo "onTransfer: ", fromAddr, " transferred ", value, " to ", toAddr
           inc notificationsReceived

--- a/tests/test_deposit_contract.nim
+++ b/tests/test_deposit_contract.nim
@@ -36,7 +36,7 @@ suite "Deposit contract":
 
       let s = await ns.subscribe(DepositEvent, %*{"fromBlock": "0x0"}) do (
           pubkey: DynamicBytes[0, 48], withdrawalCredentials: DynamicBytes[0, 32], amount: DynamicBytes[0, 8], signature: DynamicBytes[0, 96], merkleTreeIndex: DynamicBytes[0, 8])
-          {.raises: [Defect], gcsafe.}:
+          {.raises: [], gcsafe.}:
         try:
           echo "onDeposit"
           echo "pubkey: ", pubkey

--- a/tests/test_logs.nim
+++ b/tests/test_logs.nim
@@ -68,7 +68,7 @@ suite "Logs":
 
         let s = await ns.subscribe(MyEvent, %*{"fromBlock": "0x0"}) do (
             sender: Address, value: UInt256)
-            {.raises: [Defect], gcsafe.}:
+            {.raises: [], gcsafe.}:
           try:
             echo "onEvent: ", sender, " value ", value
             inc notificationsReceived

--- a/web3.nim
+++ b/web3.nim
@@ -24,7 +24,7 @@ type
     defaultAccount*: Address
     privateKey*: Option[PrivateKey]
     lastKnownNonce*: Option[Nonce]
-    onDisconnect*: proc() {.gcsafe, raises: [Defect].}
+    onDisconnect*: proc() {.gcsafe, raises: [].}
 
   Sender*[T] = ref object
     web3*: Web3
@@ -32,10 +32,10 @@ type
 
   EncodeResult* = tuple[dynamic: bool, data: string]
 
-  SubscriptionEventHandler* = proc (j: JsonNode) {.gcsafe, raises: [Defect].}
-  SubscriptionErrorHandler* = proc (err: CatchableError) {.gcsafe, raises: [Defect].}
+  SubscriptionEventHandler* = proc (j: JsonNode) {.gcsafe, raises: [].}
+  SubscriptionErrorHandler* = proc (err: CatchableError) {.gcsafe, raises: [].}
 
-  BlockHeaderHandler* = proc (b: BlockHeader) {.gcsafe, raises: [Defect].}
+  BlockHeaderHandler* = proc (b: BlockHeader) {.gcsafe, raises: [].}
 
   Subscription* = ref object
     id*: string
@@ -154,10 +154,10 @@ proc subscribeForLogs*(w: Web3, options: JsonNode,
     result.historicalEventsProcessed = true
 
 proc subscribeForBlockHeaders*(w: Web3,
-                               blockHeadersCallback: proc(b: BlockHeader) {.gcsafe, raises: [Defect].},
+                               blockHeadersCallback: proc(b: BlockHeader) {.gcsafe, raises: [].},
                                errorHandler: SubscriptionErrorHandler): Future[Subscription]
                               {.async.} =
-  proc eventHandler(json: JsonNode) {.gcsafe, raises: [Defect].} =
+  proc eventHandler(json: JsonNode) {.gcsafe, raises: [].} =
     var blk: BlockHeader
     try:
       fromJson(json, "result", blk)
@@ -465,13 +465,11 @@ macro contract*(cname: untyped, body: untyped): untyped =
           procTy = nnkProcTy.newTree(params, newEmptyNode())
           signature = getSignature(obj.eventObject)
 
-        # generated with dumpAstGen - produces "{.raises: [Defect], gcsafe.}"
+        # generated with dumpAstGen - produces "{.raises: [], gcsafe.}"
         let pragmas = nnkPragma.newTree(
           nnkExprColonExpr.newTree(
             newIdentNode("raises"),
-            nnkBracket.newTree(
-              newIdentNode("Defect")
-            )
+            nnkBracket.newTree()
           ),
           newIdentNode("gcsafe")
         )
@@ -502,7 +500,7 @@ macro contract*(cname: untyped, body: untyped): untyped =
                          withHistoricEvents = true): Future[Subscription] =
             let options = addAddressAndSignatureToOptions(options, s.contractAddress, eventTopic(`cbident`))
 
-            proc eventHandler(`jsonIdent`: JsonNode) {.gcsafe, raises: [Defect].} =
+            proc eventHandler(`jsonIdent`: JsonNode) {.gcsafe, raises: [].} =
               try:
                 `argParseBody`
                 `call`
@@ -519,7 +517,7 @@ macro contract*(cname: untyped, body: untyped): untyped =
                          withHistoricEvents = true): Future[Subscription] =
             let options = addAddressAndSignatureToOptions(options, s.contractAddress, eventTopic(`cbident`))
 
-            proc eventHandler(`jsonIdent`: JsonNode) {.gcsafe, raises: [Defect].} =
+            proc eventHandler(`jsonIdent`: JsonNode) {.gcsafe, raises: [].} =
               try:
                 `argParseBody`
                 `callWithRawData`

--- a/web3/confutils_defs.nim
+++ b/web3/confutils_defs.nim
@@ -1,15 +1,17 @@
+{.push raises: [].}
+
 import
   ethtypes
 
 func parseCmdArg*(T: type Address, input: TaintedString): T
-                 {.raises: [ValueError, Defect].} =
+                 {.raises: [ValueError].} =
   fromHex(T, string input)
 
 func completeCmdArg*(T: type Address, input: TaintedString): seq[string] =
   @[]
 
 func parseCmdArg*(T: type BlockHash, input: TaintedString): T
-                 {.raises: [ValueError, Defect].} =
+                 {.raises: [ValueError].} =
   fromHex(T, string input)
 
 func completeCmdArg*(T: type BlockHash, input: TaintedString): seq[string] =


### PR DESCRIPTION
With Nim 1.6, `Defect` does not need to be specified anymore inside `{.raises.}` and triggers redundant `XCannotRaiseY` hints. Remove.