### PR TITLE
rm `web3_consensus_const_preset`

### DIFF
--- a/web3/ethtypes.nim
+++ b/web3/ethtypes.nim
@@ -6,12 +6,8 @@ export
   hashes, options, typetraits
 
 const
-  web3_consensus_const_preset* {.strdefine.} = "mainnet"
-
-  # TODO This is not very elegant. Can we make this a run-time choice?
-  fieldElementsPerBlob = when web3_consensus_const_preset == "minimal": 4
-                         elif web3_consensus_const_preset == "mainnet": 4096
-                         else: {.error: "please set 'web3_consensus_const_preset' to either 'mainnet' or 'minimal'".}
+  # https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#blobsbundlev1
+  fieldElementsPerBlob = 4096
 
 type
   SyncObject* = object


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/pull/3521 renders it unnecessary, because `minimal` and `mainnet` presets share the same fieldElementsPerBlob now to resolve https://github.com/ethereum/consensus-specs/pull/3255 as of https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0-beta.3