### PR TITLE
re-add support for `fromBlock`, `toBlock`, `blockHash` in `eth_getLogs`

### DIFF
--- a/web3.nim
+++ b/web3.nim
@@ -258,9 +258,9 @@ proc unsubscribe*(s: Subscription): Future[void] {.async.} =
   discard await s.web3.provider.eth_unsubscribe(s.id)
 
 proc getJsonLogs(s: Web3SenderImpl, topic: Topic,
-                  fromBlock = none(RtBlockIdentifier),
-                  toBlock = none(RtBlockIdentifier),
-                  blockHash = none(BlockHash)): Future[seq[JsonString]] =
+                 fromBlock = none(RtBlockIdentifier),
+                 toBlock = none(RtBlockIdentifier),
+                 blockHash = none(BlockHash)): Future[seq[JsonString]] =
 
   var options = FilterOptions(
     address: AddressOrList(kind: slkSingle, single: s.contractAddress),
@@ -279,11 +279,11 @@ proc getJsonLogs(s: Web3SenderImpl, topic: Topic,
 
 proc getJsonLogs*[TContract](s: Sender[TContract],
                   EventName: type,
-                  fromBlock= none(RtBlockIdentifier),
+                  fromBlock = none(RtBlockIdentifier),
                   toBlock = none(RtBlockIdentifier),
                   blockHash = none(BlockHash)): Future[seq[JsonString]] {.inline.} =
   mixin eventTopic
-  getJsonLogs(s.sender, eventTopic(EventName))
+  getJsonLogs(s.sender, eventTopic(EventName), fromBlock, toBlock, blockHash)
 
 proc nextNonce*(web3: Web3): Future[Quantity] {.async.} =
   if web3.lastKnownNonce.isSome:


### PR DESCRIPTION
In #108 a regression got introduced, resulting in `fromBlock`, `toBlock` and `blockHash` no longer being sent when a client calls `eth_getLogs`. This may break the deposits import process in `nimbus-eth2`, resulting in messages such as:

```
ERR 2024-02-06 19:52:34.474+01:00 The Eth1 chain is not synced               ourDepositsCount=0 targetDepositsCount=403
```

Fixing the regression restores successful import messages:

```
INF 2024-02-06 22:12:14.863+01:00 Eth1 sync progress                         topics="elmon" blockNumber=1349452 depositsProcessed=3
```