### PR TITLE
Replace eth_getBlockReceipts return type with Opt[T] instead of Optio…

### DIFF
--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -81,16 +81,10 @@ proc installHandlers*(server: RpcServer) =
     if x != "-1".JsonString:
       result = decodeFromString(x, Quantity)
 
-  when NimMajor >= 2:
-    server.rpc("eth_getBlockReceipts") do(x: JsonString, blockId: RtBlockIdentifier) -> JsonString:
-      # TODO: cannot prove obj is not nil
-      let jsonBytes = JrpcConv.decode(x.string, string)
-      return jsonBytes.JsonString
-  else:
-    server.rpc("eth_getBlockReceipts") do(x: JsonString, blockId: RtBlockIdentifier) -> Option[seq[ReceiptObject]]:
-      if x != "-1".JsonString:
-        let r = decodeFromString(x, Option[seq[ReceiptObject]])
-        return r
+  server.rpc("eth_getBlockReceipts") do(x: JsonString, blockId: RtBlockIdentifier) -> Opt[seq[ReceiptObject]]:
+    if x != "-1".JsonString:
+      let r = decodeFromString(x, Opt[seq[ReceiptObject]])
+      return r
 
   server.rpc("eth_getBlockByNumber") do(x: JsonString, blockId: RtBlockIdentifier, fullTransactions: bool) -> BlockObject:
     var blk: BlockObject

--- a/web3/eth_api.nim
+++ b/web3/eth_api.nim
@@ -44,6 +44,9 @@ createRpcSigsFromNim(RpcClient):
   # TODO: Investigate why nim v2 cannot instantiate generic functions
   # with oneof params `blockId: BlockIdentifier` and and return type
   # Opt[seq[ReceiptObject]], this is a regression after all
+  when false:
+    proc eth_getBlockReceipts(blockId: BlockIdentifier): Opt[seq[ReceiptObject]]
+
   proc eth_getBlockReceipts(blockId: string): Opt[seq[ReceiptObject]]
   proc eth_getBlockReceipts(blockId: BlockNumber): Opt[seq[ReceiptObject]]
   proc eth_getBlockReceipts(blockId: RtBlockIdentifier): Opt[seq[ReceiptObject]]

--- a/web3/eth_api.nim
+++ b/web3/eth_api.nim
@@ -39,7 +39,7 @@ createRpcSigsFromNim(RpcClient):
   proc eth_getTransactionCount(data: Address, blockId: BlockIdentifier): Quantity
   proc eth_getBlockTransactionCountByHash(data: BlockHash): Quantity
   proc eth_getBlockTransactionCountByNumber(blockId: BlockIdentifier): Quantity
-  proc eth_getBlockReceipts(blockId: BlockIdentifier): Option[seq[ReceiptObject]]
+  proc eth_getBlockReceipts(blockId: BlockIdentifier): Opt[seq[ReceiptObject]]
   proc eth_getUncleCountByBlockHash(data: BlockHash): Quantity
   proc eth_getUncleCountByBlockNumber(blockId: BlockIdentifier): Quantity
   proc eth_getCode(data: Address, blockId: BlockIdentifier): seq[byte]

--- a/web3/eth_api.nim
+++ b/web3/eth_api.nim
@@ -11,6 +11,7 @@
 import
   std/[json, options],
   json_serialization/std/[options],
+  json_serialization/stew/results,
   json_rpc/[client, jsonmarshal],
   stint,
   ./conversions,
@@ -39,7 +40,14 @@ createRpcSigsFromNim(RpcClient):
   proc eth_getTransactionCount(data: Address, blockId: BlockIdentifier): Quantity
   proc eth_getBlockTransactionCountByHash(data: BlockHash): Quantity
   proc eth_getBlockTransactionCountByNumber(blockId: BlockIdentifier): Quantity
-  proc eth_getBlockReceipts(blockId: BlockIdentifier): Opt[seq[ReceiptObject]]
+
+  # TODO: Investigate why nim v2 cannot instantiate generic functions
+  # with oneof params `blockId: BlockIdentifier` and and return type
+  # Opt[seq[ReceiptObject]], this is a regression after all
+  proc eth_getBlockReceipts(blockId: string): Opt[seq[ReceiptObject]]
+  proc eth_getBlockReceipts(blockId: BlockNumber): Opt[seq[ReceiptObject]]
+  proc eth_getBlockReceipts(blockId: RtBlockIdentifier): Opt[seq[ReceiptObject]]
+
   proc eth_getUncleCountByBlockHash(data: BlockHash): Quantity
   proc eth_getUncleCountByBlockNumber(blockId: BlockIdentifier): Quantity
   proc eth_getCode(data: Address, blockId: BlockIdentifier): seq[byte]


### PR DESCRIPTION
…n[T]

reason:
Option[T] failed to compile when using nim v2
it is related to ref object. But also hard to reproduce outside combination of nim-json-serialization + nim-json-rpc + something