### PR TITLE
rm unused engine_exchangeTransitionConfigurationV1 calling signature

### DIFF
--- a/web3/engine_api.nim
+++ b/web3/engine_api.nim
@@ -37,7 +37,6 @@ createRpcSigsFromNim(RpcClient):
   proc engine_getPayloadV2_exact(payloadId: PayloadID): GetPayloadV2ResponseExact
   proc engine_getPayloadV3(payloadId: PayloadID): GetPayloadV3Response
   proc engine_getPayloadV4(payloadId: PayloadID): GetPayloadV4Response
-  proc engine_exchangeTransitionConfigurationV1(transitionConfiguration: TransitionConfigurationV1): TransitionConfigurationV1
   proc engine_getPayloadBodiesByHashV1(hashes: seq[BlockHash]): seq[Opt[ExecutionPayloadBodyV1]]
   proc engine_getPayloadBodiesByRangeV1(start: Quantity, count: Quantity): seq[Opt[ExecutionPayloadBodyV1]]
 


### PR DESCRIPTION
`engine_exchangeTransitionConfigurationV1` **MUST** not  be used anymore by clients,  and `nimbus-eth2` does not use it as of https://github.com/status-im/nimbus-eth2/pull/5889, so remove it.

`nimbus-eth1` can still choose to support it (though, must not require it for Dencun-scheduled networks), so leaving `TransitionConfigurationV1` in place. The removed signature is for client-side calling only, and does not affect `nimbus-eth1`.

https://github.com/ethereum/execution-apis/blob/a0d03086564ab1838b462befbc083f873dcf0c0f/src/engine/cancun.md#deprecate-engine_exchangetransitionconfigurationv1 says:
>  This document introduces deprecation of [`engine_exchangeTransitionConfigurationV1`](./paris.md#engine_exchangetransitionconfigurationv1). The deprecation is specified as follows:
>
> 1. Consensus layer clients **MUST NOT** call this method.
> 
> 2. Execution layer clients **MUST NOT** surface an error message to the user if this method is not called.

