### PR TITLE
Remove error field from AccessListResult

### DIFF
--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -213,9 +213,14 @@ suite "JSON-RPC Quantity":
     let a = JrpcConv.decode("\"0x016345785d8a0000\"", Quantity)
     check a.uint64 == 100_000_000_000_000_000'u64
     let b = JrpcConv.encode(a)
-    check b.string == "\"0x16345785d8a0000\""
+    check b == "\"0x16345785d8a0000\""
 
     let x = JrpcConv.decode("\"0xFFFF_FFFF_FFFF_FFFF\"", Quantity)
     check x.uint64 == 0xFFFF_FFFF_FFFF_FFFF_FFFF'u64
     let y = JrpcConv.encode(x)
-    check y.string == "\"0xffffffffffffffff\""
+    check y == "\"0xffffffffffffffff\""
+
+  test "AccessListResult":
+    var z: AccessListResult
+    let w = JrpcConv.encode(z)
+    check w == """{"accessList":[],"gasUsed":"0x0"}"""

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -147,6 +147,7 @@ type
     v*: Quantity                                     # ECDSA recovery id
     r*: UInt256                                      # ECDSA signature r
     s*: UInt256                                      # ECDSA signature s
+    yParity*: Option[Quantity]                       # ECDSA y parity, none for Legacy, same as v for >= Tx2930
     `type`*: Option[Quantity]                        # EIP-2718, with 0x0 for Legacy
     chainId*: Option[Quantity]                       # EIP-159
     accessList*: Option[seq[AccessTuple]]            # EIP-2930

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -130,7 +130,6 @@ type
 
   AccessListResult* = object
     accessList*: seq[AccessTuple]
-    error*: string
     gasUsed*: Quantity
 
   TransactionObject* = ref object                    # A transaction object, or null when no transaction was found:


### PR DESCRIPTION
The `error` field of `AccesListResult` is not documented anywhere, probably a mistake when it first introduced in nim-web3. And the execution_api test not detecting this because of a bug in nim-json-serialization `JsonValueRef.Object` comparison.

https://github.com/status-im/nim-json-serialization/pull/88
