### PR TITLE
Add writeValue for BlockNumber

### DIFF
--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -198,7 +198,7 @@ proc writeValue*[F: CommonJsonFlavors](w: var JsonWriter[F], v: RlpEncodedBytes)
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, distinctBase(v)
 
-proc writeValue*[F: CommonJsonFlavors](w: var JsonWriter[F], v: Quantity)
+proc writeValue*[F: CommonJsonFlavors](w: var JsonWriter[F], v: Quantity | BlockNumber)
       {.gcsafe, raises: [IOError].} =
   w.stream.write "\"0x"
   w.stream.toHex(distinctBase v)


### PR DESCRIPTION
As it is also possible to use directly BlockNumber instead of the RtBlockIdentifier in the eth_api.