### PR TITLE
Unify EthCall/EthSend into TransactionArgs

### DIFF
--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -108,11 +108,11 @@ proc installHandlers*(server: RpcServer) =
       fh = decodeFromString(x, FeeHistoryResult)
     return fh
 
-  server.rpc("eth_estimateGas") do(x: JsonString, call: EthCall) -> Quantity:
+  server.rpc("eth_estimateGas") do(x: JsonString, call: TransactionArgs) -> Quantity:
     if x != "-1".JsonString:
       result = decodeFromString(x, Quantity)
 
-  server.rpc("eth_createAccessList") do(x: JsonString, call: EthCall, blockId: RtBlockIdentifier) -> AccessListResult:
+  server.rpc("eth_createAccessList") do(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier) -> AccessListResult:
     var z: AccessListResult
     if x != "-1".JsonString:
       z = decodeFromString(x, AccessListResult)
@@ -122,7 +122,7 @@ proc installHandlers*(server: RpcServer) =
     if x != "-1".JsonString:
       result = decodeFromString(x, Quantity)
 
-  server.rpc("eth_call") do(x: JsonString, call: EthCall, blockId: RtBlockIdentifier) -> seq[byte]:
+  server.rpc("eth_call") do(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier) -> seq[byte]:
     if x != "-1".JsonString:
       result = decodeFromString(x, seq[byte])
 

--- a/tests/helpers/utils.nim
+++ b/tests/helpers/utils.nim
@@ -7,9 +7,9 @@ import
 
 proc deployContract*(web3: Web3, code: string, gasPrice = 0): Future[ReceiptObject] {.async.} =
   var code = code
-  var tr: EthSend
-  tr.`from` = web3.defaultAccount
-  tr.data = hexToSeqByte(code)
+  var tr: TransactionArgs
+  tr.`from` = some(web3.defaultAccount)
+  tr.data = some(hexToSeqByte(code))
   tr.gas = Quantity(3000000).some
   if gasPrice != 0:
     tr.gasPrice = some(gasPrice.Quantity)

--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -163,8 +163,7 @@ suite "JSON-RPC Quantity":
     checkRandomObject(StorageProof)
     checkRandomObject(ProofResponse)
     checkRandomObject(FilterOptions)
-    checkRandomObject(EthSend)
-    checkRandomObject(EthCall)
+    checkRandomObject(TransactionArgs)
 
     checkRandomObject(BlockHeader)
     checkRandomObject(BlockObject)
@@ -235,3 +234,10 @@ suite "JSON-RPC Quantity":
     var z: AccessListResult
     let w = JrpcConv.encode(z)
     check w == """{"accessList":[],"gasUsed":"0x0"}"""
+
+  test "AccessListResult with error":
+    let z = AccessListResult(
+      error: some("error")
+    )
+    let w = JrpcConv.encode(z)
+    check w == """{"accessList":[],"error":"error","gasUsed":"0x0"}"""

--- a/tests/test_signed_tx.nim
+++ b/tests/test_signed_tx.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -46,14 +46,13 @@ suite "Signed transactions":
       privateKey = PrivateKey.fromHex("0x4646464646464646464646464646464646464646464646464646464646464646").tryGet()
       publicKey = privateKey.toPublicKey()
       address = publicKey.toCanonicalAddress()
-    var tx: EthSend
+    var tx: TransactionArgs
     tx.nonce = some(Quantity(9))
-    tx.`from` = Address(address)
+    tx.`from` = some(Address(address))
     tx.value = some(1000000000000000000.u256)
     tx.to = some(Address(hexToByteArray[20]("0x3535353535353535353535353535353535353535")))
     tx.gas = some(Quantity(21000'u64))
     tx.gasPrice = some(Quantity(20000000000'i64))
-    tx.data = @[]
 
     let txBytes = encodeTransaction(tx, privateKey, ChainId(1))
     let txHex = "0x" & txBytes.toHex
@@ -71,8 +70,8 @@ suite "Signed transactions":
       let pk = PrivateKey.random(theRNG[])
       let acc = Address(toCanonicalAddress(pk.toPublicKey()))
 
-      var tx: EthSend
-      tx.`from` = accounts[0]
+      var tx: TransactionArgs
+      tx.`from` = some(accounts[0])
       tx.value = some(ethToWei(10.u256))
       tx.to = some(acc)
       tx.gasPrice = some(gasPrice)

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -41,8 +41,7 @@ LogObject.useDefaultSerializationIn JrpcConv
 StorageProof.useDefaultSerializationIn JrpcConv
 ProofResponse.useDefaultSerializationIn JrpcConv
 FilterOptions.useDefaultSerializationIn JrpcConv
-EthSend.useDefaultSerializationIn JrpcConv
-EthCall.useDefaultSerializationIn JrpcConv
+TransactionArgs.useDefaultSerializationIn JrpcConv
 FeeHistoryResult.useDefaultSerializationIn JrpcConv
 
 derefType(BlockHeader).useDefaultSerializationIn JrpcConv

--- a/web3/engine_api_types.nim
+++ b/web3/engine_api_types.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -14,10 +14,6 @@ import
 
 export
   options, stint, primitives
-
-const
-  # https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#blobsbundlev1
-  fieldElementsPerBlob = 4096
 
 type
   TypedTransaction* = distinct seq[byte]
@@ -118,10 +114,6 @@ type
     ExecutionPayloadV1 |
     ExecutionPayloadV2 |
     ExecutionPayloadV3
-
-  KZGCommitment* = FixedBytes[48]
-  KZGProof* = FixedBytes[48]
-  Blob* = FixedBytes[fieldElementsPerBlob * 32]
 
   # https://github.com/ethereum/execution-apis/blob/ee3df5bc38f28ef35385cefc9d9ca18d5e502778/src/engine/cancun.md#blobsbundlev1
   BlobsBundleV1* = object

--- a/web3/eth_api.nim
+++ b/web3/eth_api.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -44,6 +44,7 @@ createRpcSigsFromNim(RpcClient):
   # TODO: Investigate why nim v2 cannot instantiate generic functions
   # with oneof params `blockId: BlockIdentifier` and and return type
   # Opt[seq[ReceiptObject]], this is a regression after all
+  # https://github.com/nim-lang/Nim/issues/23310
   when false:
     proc eth_getBlockReceipts(blockId: BlockIdentifier): Opt[seq[ReceiptObject]]
 
@@ -55,12 +56,12 @@ createRpcSigsFromNim(RpcClient):
   proc eth_getUncleCountByBlockNumber(blockId: BlockIdentifier): Quantity
   proc eth_getCode(data: Address, blockId: BlockIdentifier): seq[byte]
   proc eth_sign(address: Address, data: seq[byte]): seq[byte]
-  proc eth_signTransaction(data: EthSend): seq[byte]
-  proc eth_sendTransaction(obj: EthSend): TxHash
+  proc eth_signTransaction(args: TransactionArgs): seq[byte]
+  proc eth_sendTransaction(args: TransactionArgs): TxHash
   proc eth_sendRawTransaction(data: seq[byte]): TxHash
-  proc eth_call(call: EthCall, blockId: BlockIdentifier): seq[byte]
-  proc eth_estimateGas(call: EthCall): Quantity
-  proc eth_createAccessList(call: EthCall, blockId: BlockIdentifier): AccessListResult
+  proc eth_call(args: TransactionArgs, blockId: BlockIdentifier): seq[byte]
+  proc eth_estimateGas(args: TransactionArgs): Quantity
+  proc eth_createAccessList(args: TransactionArgs, blockId: BlockIdentifier): AccessListResult
   proc eth_getBlockByHash(data: BlockHash, fullTransactions: bool): BlockObject
   proc eth_getBlockByNumber(blockId: BlockIdentifier, fullTransactions: bool): BlockObject
   proc eth_getTransactionByHash(data: TxHash): TransactionObject

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -291,3 +291,6 @@ func payload*(args: TransactionArgs): seq[byte] =
     return args.input.get
   if args.data.isSome:
     return args.data.get
+
+func isEIP4844*(args: TransactionArgs): bool =
+  args.maxFeePerBlobGas.isSome or args.blobVersionedHashes.isSome

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -31,28 +31,34 @@ type
     ## setting. Downstream libraries that want to enforce the up-to-date limit are
     ## expected to do this on their own.
 
-  EthSend* = object
-    `from`*: Address             # the address the transaction is sent from.
-    to*: Option[Address]         # (optional when creating new contract) the address the transaction is directed to.
-    gas*: Option[Quantity]       # (optional, default: 90000) integer of the gas provided for the transaction execution. It will return unused gas.
-    gasPrice*: Option[Quantity]  # (optional, default: To-Be-Determined) integer of the gasPrice used for each paid gas.
-    value*: Option[UInt256]      # (optional) integer of the value sent with this transaction.
-    data*: seq[byte]             # the compiled code of a contract OR the hash of the invoked method signature and encoded parameters.
-                                 # For details see Ethereum Contract ABI.
-    nonce*: Option[Quantity]     # (optional) integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce
-
-  # TODO: Both `EthSend` and `EthCall` are super outdated, according to new spec
-  # those should be merged into one type `GenericTransaction` with a lot more fields
-  # see: https://github.com/ethereum/execution-apis/blob/main/src/schemas/transaction.yaml#L244
-  EthCall* = object
+  TransactionArgs* = object
     `from`*: Option[Address]    # (optional) The address the transaction is sent from.
     to*: Option[Address]        # The address the transaction is directed to.
     gas*: Option[Quantity]      # (optional) Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions.
     gasPrice*: Option[Quantity] # (optional) Integer of the gasPrice used for each paid gas.
-    value*: Option[UInt256]     # (optional) Integer of the value sent with this transaction.
-    data*: Option[seq[byte]]    # (optional) Hash of the method signature and encoded parameters. For details see Ethereum Contract ABI.
     maxFeePerGas*: Option[Quantity]         # (optional) MaxFeePerGas is the maximum fee per gas offered, in wei.
     maxPriorityFeePerGas*: Option[Quantity] # (optional) MaxPriorityFeePerGas is the maximum miner tip per gas offered, in wei.
+    value*: Option[UInt256]     # (optional) Integer of the value sent with this transaction.
+    nonce*: Option[Quantity]    # (optional) integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce
+
+    # We accept "data" and "input" for backwards-compatibility reasons.
+    # "input" is the newer name and should be preferred by clients.
+    # Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+    data*: Option[seq[byte]]    # (optional) Hash of the method signature and encoded parameters. For details see Ethereum Contract ABI.
+    input*: Option[seq[byte]]
+
+    # Introduced by EIP-2930.
+    accessList*: Option[seq[AccessTuple]]
+    chainId*: Option[Quantity]
+
+    # EIP-4844
+    maxFeePerBlobGas*: Option[UInt256]
+    blobVersionedHashes*: Option[seq[Hash256]]
+
+    # EIP-4844 blob side car
+    blobs*: Option[Blob]
+    commitments*: Option[KZGCommitment]
+    proofs*: Option[KZGProof]
 
   ## A block header object
   BlockHeader* = ref object
@@ -130,6 +136,7 @@ type
 
   AccessListResult* = object
     accessList*: seq[AccessTuple]
+    error*: Option[string]
     gasUsed*: Quantity
 
   TransactionObject* = ref object                    # A transaction object, or null when no transaction was found:
@@ -251,11 +258,14 @@ type
 
 {.push raises: [].}
 
+func blockId*(n: uint64): RtBlockIdentifier =
+  RtBlockIdentifier(kind: bidNumber, number: BlockNumber n)
+
 func blockId*(n: BlockNumber): RtBlockIdentifier =
   RtBlockIdentifier(kind: bidNumber, number: n)
 
 func blockId*(b: BlockObject): RtBlockIdentifier =
-  RtBlockIdentifier(kind: bidNumber, number: BlockNumber b.number)
+  RtBlockIdentifier(kind: bidNumber, number: b.number)
 
 func blockId*(a: string): RtBlockIdentifier =
   RtBlockIdentifier(kind: bidAlias, alias: a)
@@ -266,11 +276,18 @@ func txOrHash*(hash: TxHash): TxOrHash =
 func txOrHash*(tx: TransactionObject): TxOrHash =
   TxOrHash(kind: tohTx, tx: tx)
 
-proc `source=`*(c: var EthCall, a: Option[Address]) =
+proc `source=`*(c: var TransactionArgs, a: Option[Address]) =
   c.`from` = a
 
-func source*(c: EthCall): Option[Address] =
+func source*(c: TransactionArgs): Option[Address] =
   c.`from`
 
 template `==`*(a, b: RlpEncodedBytes): bool =
   distinctBase(a) == distinctBase(b)
+
+func payload*(args: TransactionArgs): seq[byte] =
+  # Retrieves the transaction calldata. `input` field is preferred.
+  if args.input.isSome:
+    return args.input.get
+  if args.data.isSome:
+    return args.data.get

--- a/web3/primitives.nim
+++ b/web3/primitives.nim
@@ -14,6 +14,10 @@ import
 export
   hashes, options, typetraits
 
+const
+  # https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#blobsbundlev1
+  fieldElementsPerBlob = 4096
+
 type
   FixedBytes*[N: static[int]] = distinct array[N, byte]
 
@@ -31,6 +35,10 @@ type
   CodeHash* = FixedBytes[32]
   StorageHash* = FixedBytes[32]
   VersionedHash* = FixedBytes[32]
+
+  KZGCommitment* = FixedBytes[48]
+  KZGProof* = FixedBytes[48]
+  Blob* = FixedBytes[fieldElementsPerBlob * 32]
 
 {.push raises: [].}
 

--- a/web3/transaction_signing.nim
+++ b/web3/transaction_signing.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -39,7 +39,7 @@ func signTransactionEip155(tr: var Transaction, pk: PrivateKey) =
 
   tr.V = int64(v) + int64(chainId) * 2 + 35
 
-func encodeTransaction*(s: EthSend, pk: PrivateKey): seq[byte] =
+func encodeTransaction*(s: TransactionArgs, pk: PrivateKey): seq[byte] =
   var tr = Transaction(txType: TxLegacy)
   tr.gasLimit = s.gas.get.GasInt
   tr.gasPrice = s.gasPrice.get.GasInt
@@ -49,11 +49,11 @@ func encodeTransaction*(s: EthSend, pk: PrivateKey): seq[byte] =
   if s.value.isSome:
     tr.value = s.value.get
   tr.nonce = uint64(s.nonce.get)
-  tr.payload = s.data
+  tr.payload = s.payload
   signTransaction(tr, pk)
   return rlp.encode(tr)
 
-func encodeTransaction*(s: EthSend, pk: PrivateKey, chainId: ChainId): seq[byte] =
+func encodeTransaction*(s: TransactionArgs, pk: PrivateKey, chainId: ChainId): seq[byte] =
   var tr = Transaction(txType: TxLegacy, chainId: chainId)
   tr.gasLimit = s.gas.get.GasInt
   tr.gasPrice = s.gasPrice.get.GasInt
@@ -63,6 +63,6 @@ func encodeTransaction*(s: EthSend, pk: PrivateKey, chainId: ChainId): seq[byte]
   if s.value.isSome:
     tr.value = s.value.get
   tr.nonce = uint64(s.nonce.get)
-  tr.payload = s.data
+  tr.payload = s.payload
   signTransactionEip155(tr, pk)
   return rlp.encode(tr)


### PR DESCRIPTION
see: https://github.com/ethereum/execution-apis/blob/4b225e0d273e92982b2c539d63eaaa756c5285a4/src/schemas/transaction.yaml#L358

The execution-api schema only shows `maxFeePerBlobGas`, `blobVersionedHashes`, and `blobs` of EIP-4844.
But the reference implementation(geth), also have `commitments` and `proofs` fields.