### PR TITLE
bump `execution-apis` to `v1.0.0-beta.4`

### DIFF
--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -153,3 +153,11 @@ proc installHandlers*(server: RpcServer) =
     if x != "-1".JsonString:
       res = decodeFromString(x, seq[byte])
     return res.RlpEncodedBytes
+
+  server.rpc("eth_blobBaseFee") do(x: JsonString) -> Quantity:
+    if x != "-1".JsonString:
+      return decodeFromString(x, Quantity)
+
+  server.rpc("eth_getLogs") do(x: JsonString, filterOptions: FilterOptions) -> seq[LogObject]:
+    if x != "-1".JsonString:
+      return decodeFromString(x, seq[LogObject])


### PR DESCRIPTION
- https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-beta.4

This was already partially applied, the following commits were missing:

- update the doc of eth_getBalance to put block as required parameters
- schemas/filter: fixup some bugs in null filter topics and address
- tests: regenerate tests with new rpctestgen chain
- tests: add forkenv.json for hive
- tests: add headfcu.json
- tests: add comments in tests
- Specify Client Versions on Engine API
- Add eth_blobBaseFee; add blobs to eth_feeHistory
- Added engine_getPayloadV4 and engine_newPayloadV4 for Prague
- Update receipt.yaml to title instead of name
- Move EIP-6110 to Prague
- Add EIP-7251 to Prague
- engine: rename for 7002 partial withdrawals and 7685 requests