### PR TITLE
Respect chainId from TransactionArgs when signing

### DIFF
--- a/web3.nim
+++ b/web3.nim
@@ -304,7 +304,7 @@ proc send*(web3: Web3, c: TransactionArgs): Future[TxHash] {.async.} =
   else:
     return await web3.provider.eth_sendTransaction(c)
 
-proc send*(web3: Web3, c: TransactionArgs, chainId: ChainId): Future[TxHash] {.async.} =
+proc send*(web3: Web3, c: TransactionArgs, chainId: ChainId): Future[TxHash] {.deprecated: "Provide chainId in TransactionArgs", async.} =
   doAssert(web3.privateKey.isSome())
   var cc = c
   if cc.nonce.isNone:
@@ -325,6 +325,8 @@ proc sendData(web3: Web3,
                else: none(Quantity)
     nonce = if web3.privateKey.isSome(): some(await web3.nextNonce())
             else: none(Quantity)
+    chainId = if chainId.isSome(): some(Quantity(chainId.get))
+              else: none(Quantity)
 
     cc = TransactionArgs(
       data: some(data),
@@ -334,12 +336,10 @@ proc sendData(web3: Web3,
       value: some(value),
       nonce: nonce,
       gasPrice: gasPrice,
+      chainId: chainId
     )
 
-  if chainId.isNone:
-    return await web3.send(cc)
-  else:
-    return await web3.send(cc, chainId.get)
+  return await web3.send(cc)
 
 proc send*[T](c: ContractInvocation[T, Web3SenderImpl],
            value = 0.u256,

--- a/web3/transaction_signing.nim
+++ b/web3/transaction_signing.nim
@@ -50,10 +50,14 @@ func encodeTransaction*(s: TransactionArgs, pk: PrivateKey): seq[byte] =
     tr.value = s.value.get
   tr.nonce = uint64(s.nonce.get)
   tr.payload = s.payload
-  signTransaction(tr, pk)
+  if s.chainId.isSome():
+    tr.chainId = ChainId(s.chainId.get)
+    signTransactionEip155(tr, pk)
+  else:
+    signTransaction(tr, pk)
   return rlp.encode(tr)
 
-func encodeTransaction*(s: TransactionArgs, pk: PrivateKey, chainId: ChainId): seq[byte] =
+func encodeTransaction*(s: TransactionArgs, pk: PrivateKey, chainId: ChainId): seq[byte] {.deprecated: "Provide chainId in TransactionArgs".} =
   var tr = Transaction(txType: TxLegacy, chainId: chainId)
   tr.gasLimit = s.gas.get.GasInt
   tr.gasPrice = s.gasPrice.get.GasInt


### PR DESCRIPTION
This fixes the problem of assertion failure in `proc send*(web3: Web3, c: TransactionArgs, chainId: ChainId)`, and eliminates the need for this function along with `func encodeTransaction*(s: TransactionArgs, pk: PrivateKey, chainId: ChainId): seq[byte]` as they are redundant because `chainId` option already exists in `TransactionArgs` but was not respected during the signature. Thus these functions are marked deprecated now.

The aforementioned assertion failure happens when user provides the `chainId` without the `privateKey`, which IMO should not affect each other in the high level.
