### PR TITLE
Fix subscription handler

### DIFF
--- a/web3/contract_dsl.nim
+++ b/web3/contract_dsl.nim
@@ -47,13 +47,10 @@ type
 
 proc readValue*(r: var JsonReader[JrpcConv], val: var EventData)
        {.raises: [IOError, SerializationError].} =
-  # - First form: {"data": ..., "topics":[...]}
-  # - Second form: {"result": {"data": ..., "topics":[...]}}
   r.parseObject(key):
     case key
     of "data"  : r.readValue(val.data)
     of "topics": r.readValue(val.topics)
-    of "result": r.readValue(val)
     else: discard r.readValue(JsonString)
 
 proc joinStrings(s: varargs[string]): string = join(s)

--- a/web3/contract_dsl.nim
+++ b/web3/contract_dsl.nim
@@ -45,13 +45,7 @@ type
     data*: seq[byte]
     topics*: seq[Bytes32]
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var EventData)
-       {.raises: [IOError, SerializationError].} =
-  r.parseObject(key):
-    case key
-    of "data"  : r.readValue(val.data)
-    of "topics": r.readValue(val.topics)
-    else: discard r.readValue(JsonString)
+EventData.useDefaultSerializationIn JrpcConv
 
 proc joinStrings(s: varargs[string]): string = join(s)
 


### PR DESCRIPTION
Surprisingly the pending event bug not detected when using ganache. It only manifest after migrated to hardhat. Also not detected on linux and windows CI. Only on macos amd64 CI, and sometimes on macos arm64 CI. Probably related to async timing trigger pending event?. But it's a genuine bug, dated back far before migration from stdlib/json to json-serialization.