### PR TITLE
re-enable ObservableStores and GcUnsafe2 warnings

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,16 +1,11 @@
 # nim-web3
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-
-# nim.cfg
-@if nimHasWarningObservableStores:
-  warning[ObservableStores]: off
-@end
 
 # Avoid some rare stack corruption while using exceptions with a SEH-enabled
 # toolchain: https://github.com/status-im/nimbus-eth2/issues/3121

--- a/tests/test_contract_dsl.nim
+++ b/tests/test_contract_dsl.nim
@@ -16,11 +16,10 @@ import
 type
   DummySender = object
 
-proc createMutableContractInvocation(s: DummySender, t: typedesc, data: seq[byte]): seq[byte] = data
-proc createImmutableContractInvocation(s: DummySender, t: typedesc, data: seq[byte]): seq[byte] = data
-proc createContractDeployment(s: DummySender, t: typedesc, data: seq[byte]): seq[byte] = data
+func createMutableContractInvocation(s: DummySender, t: typedesc, data: seq[byte]): seq[byte] = data
+func createContractDeployment(s: DummySender, t: typedesc, data: seq[byte]): seq[byte] = data
 
-proc instantiateContract(t: typedesc): ContractInstance[t, DummySender] =
+func instantiateContract(t: typedesc): ContractInstance[t, DummySender] =
   discard
 
 proc checkData(a: seq[byte], expectedData: string) =

--- a/tests/test_logs.nim
+++ b/tests/test_logs.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  std/[json, random],
+  std/random,
   pkg/unittest2,
   ../web3,
   chronos, stint,

--- a/web3.nimble
+++ b/web3.nimble
@@ -34,9 +34,8 @@ proc test(args, path: string) =
 
   exec "nim " & getEnv("TEST_LANG", "c") & " " & getEnv("NIMFLAGS") & " " & args &
     " --outdir:build -r --skipParentCfg" &
-    " --warning[ObservableStores]:off --warning[GcUnsafe2]:off" &
     " --styleCheck:usages --styleCheck:error" &
-    " --hint[XDeclaredButNotUsed]:off --hint[Processing]:off " &
+    " --hint[Processing]:off " &
     path
 
 

--- a/web3/confutils_defs.nim
+++ b/web3/confutils_defs.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -16,7 +16,7 @@ export primitives
 
 func parseCmdArg*(T: type Address, input: string): T
                  {.raises: [ValueError].} =
-  fromHex(T, string input)
+  fromHex(T, input)
 
 func completeCmdArg*(T: type Address, input: string): seq[string] =
   @[]


### PR DESCRIPTION
- Neither `ObservableStores` nor `GcUnsafe2` seems to trigger in either `nimbus-eth1` or `nimbus-eth2`.
- `std/json/` was triggering an `UnusedImport` warning.
- `fromHex(T, string input)` triggers a `ConvFromXtoItselfNotNeeded` hint from `string` to `string`