### PR TITLE
Adapt encoding to ethereum

### DIFF
--- a/web3/contract_dsl.nim
+++ b/web3/contract_dsl.nim
@@ -310,7 +310,7 @@ proc genEvent(cname: NimNode, eventObject: EventObject): NimNode =
       type `cbident`* = object
 
       template eventTopic*(T: type `cbident`): eth_api_types.Bytes32 =
-        const r = Bytes32 keccak256(`signature`).data
+        const r = base.Bytes32 keccak256(`signature`).data
         r
 
       proc subscribe[TSender](s: ContractInstance[`cname`, TSender],

--- a/web3/encoding.nim
+++ b/web3/encoding.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  std/macros,
+  std/[macros, math],
   stint, ./eth_api_types, stew/[assign2, byteutils]
 
 macro makeTypeEnum(): untyped =
@@ -71,7 +71,12 @@ macro makeTypeEnum(): untyped =
 makeTypeEnum()
 
 func encode*[bits: static[int]](x: StUint[bits]): seq[byte] =
-  @(x.toByteArrayBE())
+  let numTargetBytes = bits div 8
+  let paddingBytes = 32 - numTargetBytes ## the Ethereum ABI imposes a 32 byte width for every type
+  let paddingZeros = newSeq[byte](paddingBytes)
+  let ret = paddingZeros & @(x.toByteArrayBE())
+  let retHex = ret.toHex()
+  ret
 
 func encode*[bits: static[int]](x: StInt[bits]): seq[byte] =
   @(x.toByteArrayBE())

--- a/web3/encoding.nim
+++ b/web3/encoding.nim
@@ -11,6 +11,65 @@ import
   std/macros,
   stint, ./eth_api_types, stew/[assign2, byteutils]
 
+macro makeTypeEnum(): untyped =
+  ## This macro creates all the various types of Solidity contracts and maps
+  ## them to the type used for their encoding. It also creates an enum to
+  ## identify these types in the contract signatures, along with encoder
+  ## functions used in the generated procedures.
+  result = newStmtList()
+  var lastpow2: int
+  for i in countdown(256, 8, 8):
+    let
+      identUint = newIdentNode("Uint" & $i)
+      identInt = newIdentNode("Int" & $i)
+    if ceil(log2(i.float)) == floor(log2(i.float)):
+      lastpow2 = i
+    if i notin [256, 125]: # Int/UInt256/128 are already defined in stint. No need to repeat.
+      result.add quote do:
+        type
+          `identUint`* = StUint[`lastpow2`]
+          `identInt`* = StInt[`lastpow2`]
+  let
+    identUint = ident("Uint")
+    identInt = ident("Int")
+    identBool = ident("Bool")
+  result.add quote do:
+    type
+      `identUint`* = UInt256
+      `identInt`* = Int256
+      `identBool`* = distinct Int256
+
+  for m in countup(8, 256, 8):
+    let
+      identInt = ident("Int" & $m)
+      identUint = ident("Uint" & $m)
+      identFixed = ident "Fixed" & $m
+      identUfixed = ident "Ufixed" & $m
+      identT = ident "T"
+    result.add quote do:
+      # Fixed stuff is not actually implemented yet, these procedures don't
+      # do what they are supposed to.
+      type
+        `identFixed`*[N: static[int]] = distinct `identInt`
+        `identUfixed`*[N: static[int]] = distinct `identUint`
+
+  let
+    identFixed = ident("Fixed")
+    identUfixed = ident("Ufixed")
+  result.add quote do:
+    type
+      `identFixed`* = distinct Int128
+      `identUfixed`* = distinct UInt128
+  for i in 1..256:
+    let
+      identBytes = ident("Bytes" & $i)
+      identResult = ident "result"
+    result.add quote do:
+      type
+        `identBytes`* = FixedBytes[`i`]
+
+makeTypeEnum()
+
 func encode*[bits: static[int]](x: StUint[bits]): seq[byte] =
   @(x.toByteArrayBE())
 


### PR DESCRIPTION
When sending a raw transaction to an Ethereum smart contract, we need to make sure all the types are 32-byte encoded, regardless their original type definition. For example, in `nwaku` we are dealing with a smart contract that uses `Uint32` (4 bytes) but these types need to be sent 32-byte encoded.

As an example, when performing `register` operation, we have the following parameter in the RLN smart contract: https://github.com/waku-org/waku-rlnv2-contract/blob/a576a8949ca20e310f2fbb4ec0bd05a57ac3045f/src/WakuRlnV2.sol#L141

In turn, we have the following equivalent definition in `nwaku`: https://github.com/waku-org/nwaku/blob/09f05fefe2614d640277f96ae96ab4f2f12c8031/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim#L33

---

Note: another option would be to adapt the `nwaku` codebase so that we force the use of `func encode*[N: static int](b: FixedBytes[N]): seq[byte] = encodeFixed(b.data)` instead