### PR TITLE
rm unused TransitionConfigurationV1

### DIFF
--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -212,7 +212,6 @@ suite "JSON-RPC Quantity":
     checkRandomObject(PayloadStatusV1)
     checkRandomObject(ForkchoiceStateV1)
     checkRandomObject(ForkchoiceUpdatedResponse)
-    checkRandomObject(TransitionConfigurationV1)
     checkRandomObject(GetPayloadV2Response)
     checkRandomObject(GetPayloadV2ResponseExact)
     checkRandomObject(GetPayloadV3Response)

--- a/tests/test_null_conversion.nim
+++ b/tests/test_null_conversion.nim
@@ -75,12 +75,10 @@ suite "Null conversion":
     let payloadAttributesV1 = """{ "timestamp": {item}, "prevRandao": {item}, "suggestedFeeRecipient": {item} }"""
     let forkchoiceStateV1 = """{ "status": {item}, "safeBlockHash": {item}, "finalizedBlockHash": {item} }"""
     let forkchoiceUpdatedResponse = """{ "payloadStatus": {item}, "payloadId": {item} }"""
-    let transitionConfigurationV1 = """{ "terminalTotalDifficulty": {item}, "terminalBlockHash": {item}, "terminalBlockNumber": {item} }"""
 
     var resPayloadAttributesV1: PayloadAttributesV1
     var resForkchoiceStateV1: ForkchoiceStateV1
     var resForkchoiceUpdatedResponse: ForkchoiceUpdatedResponse
-    var resTransitionConfigurationV1: TransitionConfigurationV1
 
     for item in @["\"\"", "\"0x\"", "\"0x_\"", ""]:
       template format(str: string): string =
@@ -89,7 +87,6 @@ suite "Null conversion":
       should_be_value_error(payloadAttributesV1.format(), resPayloadAttributesV1)
       should_be_value_error(forkchoiceStateV1.format(), resForkchoiceStateV1)
       should_be_value_error(forkchoiceUpdatedResponse.format(), resForkchoiceUpdatedResponse)
-      should_be_value_error(transitionConfigurationV1.format(), resTransitionConfigurationV1)
 
     template setNull(str: string): string =
       str.replace("{item}", "null")
@@ -97,7 +94,6 @@ suite "Null conversion":
     should_not_error(payloadAttributesV1.setNull(), resPayloadAttributesV1)
     should_not_error(forkchoiceStateV1.setNull(), resForkchoiceStateV1)
     should_not_error(forkchoiceUpdatedResponse.setNull(), resForkchoiceUpdatedResponse)
-    should_not_error(transitionConfigurationV1.setNull(), resTransitionConfigurationV1)
 
   ## If different status types can have branching logic
   ## we should cover each status type with different null ops

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -68,7 +68,6 @@ PayloadAttributesV1OrV2.useDefaultSerializationIn JrpcConv
 PayloadStatusV1.useDefaultSerializationIn JrpcConv
 ForkchoiceStateV1.useDefaultSerializationIn JrpcConv
 ForkchoiceUpdatedResponse.useDefaultSerializationIn JrpcConv
-TransitionConfigurationV1.useDefaultSerializationIn JrpcConv
 GetPayloadV2Response.useDefaultSerializationIn JrpcConv
 GetPayloadV2ResponseExact.useDefaultSerializationIn JrpcConv
 GetPayloadV3Response.useDefaultSerializationIn JrpcConv

--- a/web3/engine_api_types.nim
+++ b/web3/engine_api_types.nim
@@ -1,5 +1,5 @@
 # nim-web3
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -196,12 +196,6 @@ type
   ForkchoiceUpdatedResponse* = object
     payloadStatus*: PayloadStatusV1
     payloadId*: Opt[Bytes8]
-
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#transitionconfigurationv1
-  TransitionConfigurationV1* = object
-    terminalTotalDifficulty*: UInt256
-    terminalBlockHash*: Hash32
-    terminalBlockNumber*: Quantity
 
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#response-2
   GetPayloadV2Response* = object


### PR DESCRIPTION
Neither `nimbus-eth1` nor `nimbus-eth2` uses it, current CLs are prohibited from using it, and it's deprecated in an EL context.