### PR TITLE
On JSON-RPC, authorization serializes v as yParity

### DIFF
--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -196,10 +196,10 @@ suite "JSON-RPC Quantity":
     checkRandomObject(ProofResponse)
     checkRandomObject(FilterOptions)
     checkRandomObject(TransactionArgs)
-    checkRandomObject(Authorization)
 
     checkRandomObject(BlockHeader)
     checkRandomObject(BlockObject)
+    checkRandomObject(AuthorizationObject)
     checkRandomObject(TransactionObject)
     checkRandomObject(ReceiptObject)
 
@@ -275,9 +275,9 @@ suite "JSON-RPC Quantity":
     let w = JrpcConv.encode(z)
     check w == """{"accessList":[],"error":"error","gasUsed":"0x0"}"""
 
-  test "Authorization":
-    let z = Authorization()
+  test "AuthorizationObject":
+    let z = AuthorizationObject()
     let w = JrpcConv.encode(z)
-    check w == """{"chainId":"0x0","address":"0x0000000000000000000000000000000000000000","nonce":"0x0","v":"0x0","r":"0x0","s":"0x0"}"""
-    let x = JrpcConv.decode(w, Authorization)
+    check w == """{"chainId":"0x0","address":"0x0000000000000000000000000000000000000000","nonce":"0x0","yParity":"0x0","r":"0x0","s":"0x0"}"""
+    let x = JrpcConv.decode(w, AuthorizationObject)
     check x == z

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -14,12 +14,11 @@ import
   ./primitives
 
 from eth/common/blocks import Withdrawal
-from eth/common/transactions import AccessPair, Authorization
+from eth/common/transactions import AccessPair
 
 export
   primitives,
   AccessPair,
-  Authorization,
   Withdrawal
 
 type
@@ -69,7 +68,7 @@ type
     proofs*: Opt[seq[KzgProof]]
 
     # EIP-7702
-    authorizationList*: Opt[seq[Authorization]]
+    authorizationList*: Opt[seq[AuthorizationObject]]
 
   ## A block header object
   BlockHeader* = ref object
@@ -142,30 +141,38 @@ type
     error*: Opt[string]
     gasUsed*: Quantity
 
-  TransactionObject* = ref object                 # A transaction object, or null when no transaction was found:
-    hash*: Hash32                                 # hash of the transaction.
-    nonce*: Quantity                              # the number of transactions made by the sender prior to this one.
-    blockHash*: Opt[Hash32]                       # hash of the block where this transaction was in. null when its pending.
-    blockNumber*: Opt[Quantity]                   # block number where this transaction was in. null when its pending.
-    transactionIndex*: Opt[Quantity]              # integer of the transactions index position in the block. null when its pending.
-    `from`*: Address                              # address of the sender.
-    to*: Opt[Address]                             # address of the receiver. null when its a contract creation transaction.
-    value*: UInt256                               # value transferred in Wei.
-    gasPrice*: Quantity                           # gas price provided by the sender in Wei.
-    gas*: Quantity                                # gas provided by the sender.
-    input*: seq[byte]                             # the data send along with the transaction.
-    v*: Quantity                                  # ECDSA recovery id
-    r*: UInt256                                   # ECDSA signature r
-    s*: UInt256                                   # ECDSA signature s
-    yParity*: Opt[Quantity]                       # ECDSA y parity, none for Legacy, same as v for >= Tx2930
-    `type`*: Opt[Quantity]                        # EIP-2718, with 0x0 for Legacy
-    chainId*: Opt[UInt256]                        # EIP-155
-    accessList*: Opt[seq[AccessPair]]             # EIP-2930
-    maxFeePerGas*: Opt[Quantity]                  # EIP-1559
-    maxPriorityFeePerGas*: Opt[Quantity]          # EIP-1559
-    maxFeePerBlobGas*: Opt[UInt256]               # EIP-4844
-    blobVersionedHashes*: Opt[seq[VersionedHash]] # EIP-4844
-    authorizationList*: Opt[seq[Authorization]]   # EIP-7702
+  AuthorizationObject* = object  # EIP-7702
+    chainId*: ChainId
+    address*: Address
+    nonce*: AccountNonce
+    yParity*: U8Quantity
+    r*: UInt256
+    s*: UInt256
+
+  TransactionObject* = ref object                      # A transaction object, or null when no transaction was found:
+    hash*: Hash32                                      # hash of the transaction.
+    nonce*: Quantity                                   # the number of transactions made by the sender prior to this one.
+    blockHash*: Opt[Hash32]                            # hash of the block where this transaction was in. null when its pending.
+    blockNumber*: Opt[Quantity]                        # block number where this transaction was in. null when its pending.
+    transactionIndex*: Opt[Quantity]                   # integer of the transactions index position in the block. null when its pending.
+    `from`*: Address                                   # address of the sender.
+    to*: Opt[Address]                                  # address of the receiver. null when its a contract creation transaction.
+    value*: UInt256                                    # value transferred in Wei.
+    gasPrice*: Quantity                                # gas price provided by the sender in Wei.
+    gas*: Quantity                                     # gas provided by the sender.
+    input*: seq[byte]                                  # the data send along with the transaction.
+    v*: Quantity                                       # ECDSA recovery id
+    r*: UInt256                                        # ECDSA signature r
+    s*: UInt256                                        # ECDSA signature s
+    yParity*: Opt[Quantity]                            # ECDSA y parity, none for Legacy, same as v for >= Tx2930
+    `type`*: Opt[Quantity]                             # EIP-2718, with 0x0 for Legacy
+    chainId*: Opt[UInt256]                             # EIP-155
+    accessList*: Opt[seq[AccessPair]]                  # EIP-2930
+    maxFeePerGas*: Opt[Quantity]                       # EIP-1559
+    maxPriorityFeePerGas*: Opt[Quantity]               # EIP-1559
+    maxFeePerBlobGas*: Opt[UInt256]                    # EIP-4844
+    blobVersionedHashes*: Opt[seq[VersionedHash]]      # EIP-4844
+    authorizationList*: Opt[seq[AuthorizationObject]]  # EIP-7702
 
   ReceiptObject* = ref object        # A transaction receipt object, or null when no receipt was found:
     transactionHash*: Hash32         # hash of the transaction.

--- a/web3/primitives.nim
+++ b/web3/primitives.nim
@@ -39,6 +39,7 @@ type
     minLen: static[int] = 0,
     maxLen: static[int] = high(int)] = distinct seq[byte]
 
+  U8Quantity* = distinct uint8
   Quantity* = distinct uint64
     # Quantity is use in lieu of an ordinary `uint64` to avoid the default
     # format that comes with json_serialization


### PR DESCRIPTION
JSON uses yParity for authorization instead of v like in transaction, because v for transaction has additional information mixed in in legacy case (chain ID and magic value); this legacy case is not relevant for authorizations. Existing logic ignored yParity value from JSON and uses default initialized v = 0 value. Create our own web3 type, same as how we do it for transactions and receipts, and use correct yParity key.