### PR TITLE
Replace PooledTransaction usage from test with BlobTx

### DIFF
--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -13,7 +13,8 @@ import
   json_rpc/rpcserver,
   ../../web3/conversions,
   ../../web3/eth_api_types,
-  ../../web3/primitives as w3
+  ../../web3/primitives as w3,
+  ./min_blobtx_rlp
 
 type
   Hash32 = w3.Hash32
@@ -29,8 +30,8 @@ proc installHandlers*(server: RpcServer) =
     return SyncingStatus(syncing: false)
 
   server.rpc("eth_sendRawTransaction") do(x: JsonString, data: seq[byte]) -> Hash32:
-    let tx = rlp.decode(data, PooledTransaction)
-    let h = rlpHash(tx)
+    let tx = rlp.decode(data, BlobTransaction)
+    let h = computeRlpHash(tx.tx)
     return Hash32(h.data)
 
   server.rpc("eth_getTransactionReceipt") do(x: JsonString, data: Hash32) -> ReceiptObject:

--- a/tests/helpers/min_blobtx_rlp.nim
+++ b/tests/helpers/min_blobtx_rlp.nim
@@ -1,0 +1,29 @@
+{.push raises: [].}
+
+import
+  eth/common/transactions_rlp {.all.}
+
+type
+  # Pretend to be a PooledTransaction
+  # for testing purpose
+  BlobTransaction* = object
+    tx*: Transaction
+
+proc readTxTyped(rlp: var Rlp, tx: var BlobTransaction) {.raises: [RlpError].} =
+  let
+    txType = rlp.readTxType()
+    numFields =
+      if txType == TxEip4844:
+        rlp.listLen
+      else:
+        1
+  if numFields == 4 or numFields == 5:
+    rlp.tryEnterList() # spec: rlp([tx_payload, blobs, commitments, proofs])
+  rlp.readTxPayload(tx.tx, txType)
+  # ignore BlobBundle
+
+proc read*(rlp: var Rlp, T: type BlobTransaction): T {.raises: [RlpError].} =
+  if rlp.isList:
+    rlp.readTxLegacy(result.tx)
+  else:
+    rlp.readTxTyped(result)

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -12,7 +12,7 @@ import
   stew/byteutils,
   faststreams/textio,
   json_rpc/jsonmarshal,
-  json_serialization/pkg/results,
+  json_serialization/stew/results,
   json_serialization,
   ./primitives,
   ./engine_api_types,

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -12,7 +12,7 @@ import
   stew/byteutils,
   faststreams/textio,
   json_rpc/jsonmarshal,
-  json_serialization/stew/results,
+  json_serialization/pkg/results,
   json_serialization,
   ./primitives,
   ./engine_api_types,


### PR DESCRIPTION
Since PooledTransaction has been removed from nim-eth. We only need a minimum rlp reader to pass the test. And make clear the distinction between PooledTransaction hash and inner tx hash.