### PR TITLE
Replace JrpcConv by custom EthJson flavor

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-npm install hardhat@3
+npm install hardhat@3.3
 npm pkg set type="module"
 echo "export default {};" > hardhat.config.js
 npx hardhat --version

--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -67,6 +67,12 @@ proc installHandlers*(server: RpcServer) =
       if x != "-1".JsonString:
         result = decodeFromString(x, FixedBytes[32])
 
+    proc eth_getStorageValues(x: JsonString, address: Address, slots: seq[UInt256], blockId: RtBlockIdentifier): ProofResponse {.raises: [SerializationError].} =
+      var res: StorageValuesResponse
+      if x != "-1".JsonString:
+        res = decodeFromString(x, StorageValuesResponse)
+      return res
+
     proc eth_getProof(x: JsonString, address: Address, slots: seq[UInt256], blockId: RtBlockIdentifier): ProofResponse {.raises: [SerializationError].} =
       var p: ProofResponse
       if x != "-1".JsonString:

--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -22,155 +22,150 @@ type
   FixedBytes[N: static int] = w3.FixedBytes[N]
 
 func decodeFromString(x: JsonString, T: type): T =
-  let jsonBytes = JrpcConv.decode(x.string, string)
-  result = JrpcConv.decode(jsonBytes, T)
+  let jsonBytes = EthJson.decode(x.string, string)
+  result = EthJson.decode(jsonBytes, T)
 
 proc installHandlers*(server: RpcServer) =
-  server.rpc("eth_syncing") do(x: JsonString) -> SyncingStatus:
-    return SyncingStatus(syncing: false)
+  server.rpc(EthJson):
+    proc eth_syncing(x: JsonString): SyncingStatus {.raises: [].} =
+      return SyncingStatus(syncing: false)
 
-  server.rpc("eth_sendRawTransaction") do(x: JsonString, data: seq[byte]) -> Hash32:
-    let tx = rlp.decode(data, BlobTransaction)
-    let h = computeRlpHash(tx.tx)
-    return Hash32(h.data)
+    proc eth_sendRawTransaction(x: JsonString, data: seq[byte]): Hash32 {.raises: [RlpError].} =
+      let tx = rlp.decode(data, BlobTransaction)
+      let h = computeRlpHash(tx.tx)
+      return Hash32(h.data)
 
-  server.rpc("eth_getTransactionReceipt") do(x: JsonString, data: Hash32) -> ReceiptObject:
-    var r: ReceiptObject
-    if x != "-1".JsonString:
-      r = decodeFromString(x, ReceiptObject)
-    return r
-
-  server.rpc("eth_getTransactionByHash") do(x: JsonString, data: Hash32) -> TransactionObject:
-    var tx: TransactionObject
-    if x != "-1".JsonString:
-      tx = decodeFromString(x, TransactionObject)
-    return tx
-
-  server.rpc("eth_getTransactionByBlockNumberAndIndex") do(x: JsonString, blockId: RtBlockIdentifier, quantity: Quantity) -> TransactionObject:
-    var tx: TransactionObject
-    if x != "-1".JsonString:
-      tx = decodeFromString(x, TransactionObject)
-    return tx
-
-  server.rpc("eth_getTransactionByBlockHashAndIndex") do(x: JsonString, data: Hash32, quantity: Quantity) -> TransactionObject:
-    var tx: TransactionObject
-    if x != "-1".JsonString:
-      tx = decodeFromString(x, TransactionObject)
-    return tx
-
-  server.rpc("eth_getTransactionCount") do(x: JsonString, data: Address, blockId: RtBlockIdentifier) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
-
-  server.rpc("eth_getStorageAt") do(x: JsonString, data: Address, slot: UInt256, blockId: RtBlockIdentifier) -> FixedBytes[32]:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, FixedBytes[32])
-
-  server.rpc("eth_getStorageValues") do(x: JsonString, request: StorageValuesRequest, blockTag: RtBlockIdentifier) -> StorageValuesResponse:
-    var res: StorageValuesResponse
-    if x != "-1".JsonString:
-      res = decodeFromString(x, StorageValuesResponse)
-    return res
-
-  server.rpc("eth_getProof") do(x: JsonString, address: Address, slots: seq[UInt256], blockId: RtBlockIdentifier) -> ProofResponse:
-    var p: ProofResponse
-    if x != "-1".JsonString:
-      p = decodeFromString(x, ProofResponse)
-    return p
-
-  server.rpc("eth_getCode") do(x: JsonString, data: Address, blockId: RtBlockIdentifier) -> seq[byte]:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, seq[byte])
-
-  server.rpc("eth_getBlockTransactionCountByNumber") do(x: JsonString, blockId: RtBlockIdentifier) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
-
-  server.rpc("eth_getBlockTransactionCountByHash") do(x: JsonString, data: Hash32) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
-
-  server.rpc("eth_getBlockReceipts") do(x: JsonString, blockId: RtBlockIdentifier) -> Opt[seq[ReceiptObject]]:
-    if x != "-1".JsonString:
-      let r = decodeFromString(x, Opt[seq[ReceiptObject]])
+    proc eth_getTransactionReceipt(x: JsonString, data: Hash32): ReceiptObject {.raises: [SerializationError].} =
+      var r: ReceiptObject
+      if x != "-1".JsonString:
+        r = decodeFromString(x, ReceiptObject)
       return r
 
-  server.rpc("eth_getBlockByNumber") do(x: JsonString, blockId: RtBlockIdentifier, fullTransactions: bool) -> BlockObject:
-    var blk: BlockObject
-    if x != "-1".JsonString:
-      blk = decodeFromString(x, BlockObject)
-    return blk
+    proc eth_getTransactionByHash(x: JsonString, data: Hash32): TransactionObject {.raises: [SerializationError].} =
+      var tx: TransactionObject
+      if x != "-1".JsonString:
+        tx = decodeFromString(x, TransactionObject)
+      return tx
 
-  server.rpc("eth_getBlockByHash") do(x: JsonString, data: Hash32, fullTransactions: bool) -> BlockObject:
-    var blk: BlockObject
-    if x != "-1".JsonString:
-      blk = decodeFromString(x, BlockObject)
-    return blk
+    proc eth_getTransactionByBlockNumberAndIndex(x: JsonString, blockId: RtBlockIdentifier, quantity: Quantity): TransactionObject {.raises: [SerializationError].} =
+      var tx: TransactionObject
+      if x != "-1".JsonString:
+        tx = decodeFromString(x, TransactionObject)
+      return tx
 
-  server.rpc("eth_getBalance") do(x: JsonString, data: Address, blockId: RtBlockIdentifier) -> UInt256:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, UInt256)
+    proc eth_getTransactionByBlockHashAndIndex(x: JsonString, data: Hash32, quantity: Quantity): TransactionObject {.raises: [SerializationError].} =
+      var tx: TransactionObject
+      if x != "-1".JsonString:
+        tx = decodeFromString(x, TransactionObject)
+      return tx
 
-  server.rpc("eth_feeHistory") do(x: JsonString, blockCount: Quantity, newestBlock: RtBlockIdentifier, rewardPercentiles: Opt[seq[float64]]) -> FeeHistoryResult:
-    var fh: FeeHistoryResult
-    if x != "-1".JsonString:
-      fh = decodeFromString(x, FeeHistoryResult)
-    return fh
+    proc eth_getTransactionCount(x: JsonString, data: Address, blockId: RtBlockIdentifier): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
 
-  server.rpc("eth_estimateGas") do(x: JsonString, call: TransactionArgs) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
+    proc eth_getStorageAt(x: JsonString, data: Address, slot: UInt256, blockId: RtBlockIdentifier): FixedBytes[32] {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, FixedBytes[32])
 
-  server.rpc("eth_createAccessList") do(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier) -> AccessListResult:
-    var z: AccessListResult
-    if x != "-1".JsonString:
-      z = decodeFromString(x, AccessListResult)
-    return z
+    proc eth_getProof(x: JsonString, address: Address, slots: seq[UInt256], blockId: RtBlockIdentifier): ProofResponse {.raises: [SerializationError].} =
+      var p: ProofResponse
+      if x != "-1".JsonString:
+        p = decodeFromString(x, ProofResponse)
+      return p
 
-  server.rpc("eth_chainId") do(x: JsonString, ) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
+    proc eth_getCode(x: JsonString, data: Address, blockId: RtBlockIdentifier): seq[byte] {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, seq[byte])
 
-  server.rpc("eth_call") do(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier) -> seq[byte]:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, seq[byte])
+    proc eth_getBlockTransactionCountByNumber(x: JsonString, blockId: RtBlockIdentifier): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
 
-  server.rpc("eth_blockNumber") do(x: JsonString) -> Quantity:
-    if x != "-1".JsonString:
-      result = decodeFromString(x, Quantity)
+    proc eth_getBlockTransactionCountByHash(x: JsonString, data: Hash32): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
 
-  server.rpc("debug_getRawTransaction") do(x: JsonString, data: Bytes32) -> RlpEncodedBytes:
-    var res: seq[byte]
-    if x != "-1".JsonString:
-      res = decodeFromString(x, seq[byte])
-    return res.RlpEncodedBytes
+    proc eth_getBlockReceipts(x: JsonString, blockId: RtBlockIdentifier): Opt[seq[ReceiptObject]] {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        let r = decodeFromString(x, Opt[seq[ReceiptObject]])
+        return r
 
-  server.rpc("debug_getRawReceipts") do(x: JsonString, blockId: RtBlockIdentifier) -> seq[RlpEncodedBytes]:
-    var res: seq[RlpEncodedBytes]
-    if x != "-1".JsonString:
-      res = decodeFromString(x, seq[RlpEncodedBytes])
-    return res
+    proc eth_getBlockByNumber(x: JsonString, blockId: RtBlockIdentifier, fullTransactions: bool): BlockObject {.raises: [SerializationError].} =
+      var blk: BlockObject
+      if x != "-1".JsonString:
+        blk = decodeFromString(x, BlockObject)
+      return blk
 
-  server.rpc("debug_getRawHeader") do(x: JsonString, blockId: RtBlockIdentifier) -> RlpEncodedBytes:
-    var res: seq[byte]
-    if x != "-1".JsonString:
-      res = decodeFromString(x, seq[byte])
-    return res.RlpEncodedBytes
+    proc eth_getBlockByHash(x: JsonString, data: Hash32, fullTransactions: bool): BlockObject {.raises: [SerializationError].} =
+      var blk: BlockObject
+      if x != "-1".JsonString:
+        blk = decodeFromString(x, BlockObject)
+      return blk
 
-  server.rpc("debug_getRawBlock") do(x: JsonString, blockId: RtBlockIdentifier) -> RlpEncodedBytes:
-    var res: seq[byte]
-    if x != "-1".JsonString:
-      res = decodeFromString(x, seq[byte])
-    return res.RlpEncodedBytes
+    proc eth_getBalance(x: JsonString, data: Address, blockId: RtBlockIdentifier): UInt256 {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, UInt256)
 
-  server.rpc("eth_blobBaseFee") do(x: JsonString) -> Quantity:
-    if x != "-1".JsonString:
-      return decodeFromString(x, Quantity)
+    proc eth_feeHistory(x: JsonString, blockCount: Quantity, newestBlock: RtBlockIdentifier, rewardPercentiles: Opt[seq[float64]]): FeeHistoryResult {.raises: [SerializationError].} =
+      var fh: FeeHistoryResult
+      if x != "-1".JsonString:
+        fh = decodeFromString(x, FeeHistoryResult)
+      return fh
 
-  server.rpc("eth_getLogs") do(x: JsonString, filterOptions: FilterOptions) -> seq[LogObject]:
-    if x != "-1".JsonString:
-      return decodeFromString(x, seq[LogObject])
+    proc eth_estimateGas(x: JsonString, call: TransactionArgs): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
 
-  server.rpc("net_version") do(x: JsonString) -> string:
-    if x != "-1".JsonString:
-      return decodeFromString(x, string)
+    proc eth_createAccessList(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier): AccessListResult {.raises: [SerializationError].} =
+      var z: AccessListResult
+      if x != "-1".JsonString:
+        z = decodeFromString(x, AccessListResult)
+      return z
+
+    proc eth_chainId(x: JsonString, ): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
+
+    proc eth_call(x: JsonString, call: TransactionArgs, blockId: RtBlockIdentifier): seq[byte] {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, seq[byte])
+
+    proc eth_blockNumber(x: JsonString): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        result = decodeFromString(x, Quantity)
+
+    proc debug_getRawTransaction(x: JsonString, data: Bytes32): RlpEncodedBytes {.raises: [SerializationError].} =
+      var res: seq[byte]
+      if x != "-1".JsonString:
+        res = decodeFromString(x, seq[byte])
+      return res.RlpEncodedBytes
+
+    proc debug_getRawReceipts(x: JsonString, blockId: RtBlockIdentifier): seq[RlpEncodedBytes] {.raises: [SerializationError].} =
+      var res: seq[RlpEncodedBytes]
+      if x != "-1".JsonString:
+        res = decodeFromString(x, seq[RlpEncodedBytes])
+      return res
+
+    proc debug_getRawHeader(x: JsonString, blockId: RtBlockIdentifier): RlpEncodedBytes {.raises: [SerializationError].} =
+      var res: seq[byte]
+      if x != "-1".JsonString:
+        res = decodeFromString(x, seq[byte])
+      return res.RlpEncodedBytes
+
+    proc debug_getRawBlock(x: JsonString, blockId: RtBlockIdentifier): RlpEncodedBytes {.raises: [SerializationError].} =
+      var res: seq[byte]
+      if x != "-1".JsonString:
+        res = decodeFromString(x, seq[byte])
+      return res.RlpEncodedBytes
+
+    proc eth_blobBaseFee(x: JsonString): Quantity {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        return decodeFromString(x, Quantity)
+
+    proc eth_getLogs(x: JsonString, filterOptions: FilterOptions): seq[LogObject] {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        return decodeFromString(x, seq[LogObject])
+
+    proc net_version(x: JsonString): string {.raises: [SerializationError].} =
+      if x != "-1".JsonString:
+        return decodeFromString(x, string)

--- a/tests/helpers/handlers.nim
+++ b/tests/helpers/handlers.nim
@@ -67,7 +67,7 @@ proc installHandlers*(server: RpcServer) =
       if x != "-1".JsonString:
         result = decodeFromString(x, FixedBytes[32])
 
-    proc eth_getStorageValues(x: JsonString, address: Address, slots: seq[UInt256], blockId: RtBlockIdentifier): ProofResponse {.raises: [SerializationError].} =
+    proc eth_getStorageValues(x: JsonString, request: StorageValuesRequest, blockTag: RtBlockIdentifier): StorageValuesResponse {.raises: [SerializationError].} =
       var res: StorageValuesResponse
       if x != "-1".JsonString:
         res = decodeFromString(x, StorageValuesResponse)

--- a/tests/test_execution_api.nim
+++ b/tests/test_execution_api.nim
@@ -21,7 +21,8 @@ const
 
 {.push raises: [].}
 
-JrpcConv.automaticSerialization(JsonValueRef, true)
+# XXX explicit readValue/writeValue to avoid automatic serialization
+EthJson.automaticSerialization(JsonValueRef, true)
 
 func compareValue(lhs, rhs: JsonValueRef): bool
 
@@ -136,7 +137,7 @@ proc callWithParams(client: RpcClient, data: TestData): Future[bool] {.async.} =
   try:
     var params = data.input.params
     if data.output.result.string.len > 0:
-      let jsonBytes = JrpcConv.encode(data.output.result.string)
+      let jsonBytes = EthJson.encode(data.output.result.string)
       params.positional.insert(jsonBytes.JsonString, 0)
     else:
       params.positional.insert("-1".JsonString, 0)
@@ -144,8 +145,8 @@ proc callWithParams(client: RpcClient, data: TestData): Future[bool] {.async.} =
     let resJson = await client.call(data.input.`method`, params)
 
     if res.result.string.len > 0:
-      let wantVal = JrpcConv.decode(res.result.string, JsonValueRef[string])
-      let getVal = JrpcConv.decode(resJson.string, JsonValueRef[string])
+      let wantVal = EthJson.decode(res.result.string, JsonValueRef[string])
+      let getVal = EthJson.decode(resJson.string, JsonValueRef[string])
 
       if not compareValue(wantVal, getVal):
         debugEcho data.file
@@ -203,7 +204,7 @@ suite "Ethereum execution api":
   waitFor srv.closeWait()
 
 proc setupMethods(server: RpcServer) =
-  server.rpc("eth_getBlockReceipts") do(blockId: RtBlockIdentifier) -> Opt[seq[ReceiptObject]]:
+  server.rpc("eth_getBlockReceipts", EthJson) do(blockId: RtBlockIdentifier) -> Opt[seq[ReceiptObject]]:
     var res: seq[ReceiptObject]
     return Opt.some(res)
 

--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -13,7 +13,7 @@ import
   unittest2,
   nimcrypto,
   stew/endians2,
-  json_rpc/jsonmarshal, json_serialization,
+  json_serialization,
   ../web3/engine_api_types,
   ../web3/execution_types,
   ../web3/[conversions, eth_api_types]
@@ -128,9 +128,9 @@ proc rand[X: ref](T: type X): T =
 
 template checkRandomObject(T: type) =
   let obj = rand(T)
-  let bytes = JrpcConv.encode(obj)
-  let decoded = JrpcConv.decode(bytes, T)
-  let bytes2 = JrpcConv.encode(decoded)
+  let bytes = EthJson.encode(obj)
+  let decoded = EthJson.decode(bytes, T)
+  let bytes2 = EthJson.encode(decoded)
   check bytes == bytes2
 
 suite "JSON-RPC Quantity":
@@ -138,14 +138,14 @@ suite "JSON-RPC Quantity":
     template checkType(typeName: typedesc, tests: auto): untyped =
       for (validStr, validValue) in tests:
         let
-          validJson = JrpcConv.encode(validStr)
-          res = JrpcConv.decode(validJson, typeName)
-          resUInt256 = JrpcConv.decode(validJson, UInt256)
-          resUInt256Ref = JrpcConv.decode(validJson, ref UInt256)
+          validJson = EthJson.encode(validStr)
+          res = EthJson.decode(validJson, typeName)
+          resUInt256 = EthJson.decode(validJson, UInt256)
+          resUInt256Ref = EthJson.decode(validJson, ref UInt256)
 
         check:
-          JrpcConv.decode(validJson, typeName) == typeName validValue
-          JrpcConv.encode(typeName validValue) == validJson
+          EthJson.decode(validJson, typeName) == typeName validValue
+          EthJson.encode(typeName validValue) == validJson
           res == typeName(validValue)
           resUInt256 == typeName(validValue).distinctBase.u256
           resUInt256Ref[] == typeName(validValue).distinctBase.u256
@@ -160,8 +160,8 @@ suite "JSON-RPC Quantity":
       template checkInvalids(typeName: untyped) =
         var res: `typeName`
         try:
-          let jsonBytes = JrpcConv.encode(invalidStr)
-          res = JrpcConv.decode(jsonBytes, `typeName`)
+          let jsonBytes = EthJson.encode(invalidStr)
+          res = EthJson.decode(jsonBytes, `typeName`)
           echo `typeName`, " ", invalidStr
           check: false
         except SerializationError:
@@ -178,11 +178,11 @@ suite "JSON-RPC Quantity":
      {"difficulty":"0x1","extraData":"0x696e667572612d696f00000000000000000000000000000000000000000000004ede22d16eaf5bbab47534ee64a1ec1728ed63b1243672ee9623532fffd747b368cddb4674f849e467884f0e6c6563440ea5fd812cc33fcd19fb9c323b0c92c300","gasLimit":"0x7a1200","gasUsed":"0x3aca3e","hash":"0x5ac670562dbf877a45039d65ec3c2e3402a40eda9b1dba931c2376ab7d0927c2","logsBloom":"0x40000000004000120000000100030000882000040000001800010000020000000000000000001400080040004080400402024800000004000088f0320000a0000016000100110060800000080000020000000020000000000050000009010000080000040220280000080240048008000001381a1100000000000010000440000000004200000018001102280400003040040020001a000026000488000101000120000a0002000081220000100000000200000000040440a02400010000000002000002400100840000080000000080000008c0c080000008000000220860082002000000001000000041040002000000008000010004000400010400040001","miner":"0x0000000000000000000000000000000000000000","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x42a3da","parentHash":"0xe0190ed0683835483c35e0c0a98bf0958ed2ca7313428c9026db51604007e299","receiptsRoot":"0x12fff235455db65dcdc525d2491b9e0526e02d70a1515fba155b1de9f648abf3","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2a5d","stateRoot":"0xccb37180b5fca41e43395d524a0ee83a1efc69f2fb61f90a51f3dc8f40f2144e","timestamp":"0x603cab8c","totalDifficulty":"0x624910","transactions":["0xa3c07dc59bfdb1bfc2d50920fed2ef2c1c4e0a09fe2325dbc14e07702f965a78","0x7b33b36e905c8e83a519216444aff4952bfbce5c49247ecc70f227a56068247e","0x11fa3f25957caa1918ecb1f2c1eaeef46c1af983e1b7eee65cefe2a752f7e9da","0x7028ef43993c84e751bbcb126cbaa52d7b732efe4daf95e6e0fbff06e43f0277","0xe287b4939a51aff8a78b836c56db18ca1559ba77303b1e0cee9075ff737f4a57","0xb79cb96a3ff5bb9aca4ce2024a57023cfda163d6135f3ff6a0d9f0b9fac44efb","0xad0d4bfb6b4276616c7d88fe2576903d6c17f6bee1d10db15de203a88bda2898","0x73127fadab4c4ceed35be81e3e97549d2005bfdbc49083ce81f135662edd6869","0xff522f3e2a2d451acf2df2341d8ed9e982dbf7160b327f34b8b5ca25b377a74f","0x2d100b5abba751743920cf56614195c0e3685d93bfdbe5325c35a933f5195e2c","0x9611c7cac2e14fed4051d34f74eed1bace9da8e79446d4e03f479c318de24087","0x43f29106dac821e5069b3c0b27a61d01116a8e69096388d57b70a9e5354e0457","0xb71fe345141491f54cb53e4af44d581cbd631c0b7bd12019077c1dc354b1c5ab"],"transactionsRoot":"0x08fd011674202c6df63822f877e88d7ca0fe41e5deb8bc2b8830f1a29ce864f0","uncles":[]}
     """
     let
-      b1 = JrpcConv.decode(blockJson, BlockObject)
-      jsonBytes = JrpcConv.encode(b1)
-      b2 = JrpcConv.decode(jsonBytes, BlockObject)
-      b1Bytes = JrpcConv.encode(b1)
-      b2Bytes = JrpcConv.encode(b2)
+      b1 = EthJson.decode(blockJson, BlockObject)
+      jsonBytes = EthJson.encode(b1)
+      b2 = EthJson.decode(jsonBytes, BlockObject)
+      b1Bytes = EthJson.encode(b1)
+      b2Bytes = EthJson.encode(b2)
 
     check b1Bytes == b2Bytes
 
@@ -237,8 +237,8 @@ suite "JSON-RPC Quantity":
 
   test "check blockId":
     let a = RtBlockIdentifier(kind: bidNumber, number: 77.Quantity)
-    let x = JrpcConv.encode(a)
-    let c = JrpcConv.decode(x, RtBlockIdentifier)
+    let x = EthJson.encode(a)
+    let c = EthJson.decode(x, RtBlockIdentifier)
     check c.kind == bidNumber
     check c.number == 77.Quantity
 
@@ -252,7 +252,7 @@ suite "JSON-RPC Quantity":
       discard invalid
 
     expect JsonReaderError:
-      let d = JrpcConv.decode("10", RtBlockIdentifier)
+      let d = EthJson.decode("10", RtBlockIdentifier)
       discard d
 
     const w = hash32"0x0012c7b99594801d513ae92396379e5ffcf60e23127cbcabb166db28586f01aa"
@@ -284,40 +284,40 @@ suite "JSON-RPC Quantity":
 
   test "check address or list":
     let a = AddressOrList(kind: slkNull)
-    let x = JrpcConv.encode(a)
-    let c = JrpcConv.decode(x, AddressOrList)
+    let x = EthJson.encode(a)
+    let c = EthJson.decode(x, AddressOrList)
     check c.kind == slkNull
 
   test "quantity parser and writer":
     template checkType(typeName: typedesc): untyped =
       block:
-        let a = JrpcConv.decode("\"0x016345785d8a0000\"", typeName)
+        let a = EthJson.decode("\"0x016345785d8a0000\"", typeName)
         check a.uint64 == 100_000_000_000_000_000'u64
-        let b = JrpcConv.encode(a)
+        let b = EthJson.encode(a)
         check b == "\"0x16345785d8a0000\""
 
-        let x = JrpcConv.decode("\"0xFFFF_FFFF_FFFF_FFFF\"", typeName)
-        check x.uint64 == 0xFFFF_FFFF_FFFF_FFFF'u64
-        let y = JrpcConv.encode(x)
+        let x = EthJson.decode("\"0xFFFF_FFFF_FFFF_FFFF\"", typeName)
+        check x.uint64 == 0xFFFF_FFFF_FFFF_FFFF_FFFF'u64
+        let y = EthJson.encode(x)
         check y == "\"0xffffffffffffffff\""
 
     checkType(Quantity)
 
   test "AccessListResult":
     let z = AccessListResult()
-    let w = JrpcConv.encode(z)
+    let w = EthJson.encode(z)
     check w == """{"accessList":[],"error":null,"gasUsed":"0x0"}"""
 
   test "AccessListResult with error":
     let z = AccessListResult(
       error: Opt.some("error")
     )
-    let w = JrpcConv.encode(z)
+    let w = EthJson.encode(z)
     check w == """{"accessList":[],"error":"error","gasUsed":"0x0"}"""
 
   test "Authorization":
     let z = Authorization(yParity: 3, nonce: 11)
-    let w = JrpcConv.encode(z)
+    let w = EthJson.encode(z)
     check w == """{"chainId":"0x0","address":"0x0000000000000000000000000000000000000000","nonce":"0xb","yParity":"0x3","r":"0x0","s":"0x0"}"""
-    let x = JrpcConv.decode(w, Authorization)
+    let x = EthJson.decode(w, Authorization)
     check x == z

--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -242,13 +242,13 @@ suite "JSON-RPC Quantity":
     check c.kind == bidNumber
     check c.number == 77.Quantity
 
-    let d = JrpcConv.decode("\"latest\"", RtBlockIdentifier)
+    let d = EthJson.decode("\"latest\"", RtBlockIdentifier)
     check d.kind == bidAlias
     check d.alias == "latest"
 
     # https://github.com/ethereum/execution-apis/blob/main/tests/debug_getRawBlock/get-invalid-number.io
     expect JsonReaderError:
-      let invalid = JrpcConv.decode("\"10\"", RtBlockIdentifier)
+      let invalid = EthJson.decode("\"10\"", RtBlockIdentifier)
       discard invalid
 
     expect JsonReaderError:
@@ -256,28 +256,28 @@ suite "JSON-RPC Quantity":
       discard d
 
     const w = hash32"0x0012c7b99594801d513ae92396379e5ffcf60e23127cbcabb166db28586f01aa"
-    let e = JrpcConv.decode("\"" & $w & "\"", RtBlockIdentifier)
+    let e = EthJson.decode("\"" & $w & "\"", RtBlockIdentifier)
     check e.kind == bidHash
     check e.hash == w
 
     # EIP-1898 object form: blockHash
-    let f = JrpcConv.decode("{\"blockHash\":\"" & $w & "\"}", RtBlockIdentifier)
+    let f = EthJson.decode("{\"blockHash\":\"" & $w & "\"}", RtBlockIdentifier)
     check f.kind == bidHash
     check f.hash == w
 
     # EIP-1898 object form: blockNumber
-    let g = JrpcConv.decode("{\"blockNumber\":\"0x77\"}", RtBlockIdentifier)
+    let g = EthJson.decode("{\"blockNumber\":\"0x77\"}", RtBlockIdentifier)
     check g.kind == bidNumber
     check g.number == 0x77.Quantity
 
     # EIP-1898 object form: blockHash with requireCanonical=false
-    let h = JrpcConv.decode("{\"blockHash\":\"" & $w & "\",\"requireCanonical\":false}", RtBlockIdentifier)
+    let h = EthJson.decode("{\"blockHash\":\"" & $w & "\",\"requireCanonical\":false}", RtBlockIdentifier)
     check h.kind == bidHash
     check h.hash == w
     check h.requireCanonical == false
 
     # EIP-1898 object form: blockHash with requireCanonical=true
-    let i = JrpcConv.decode("{\"blockHash\":\"" & $w & "\",\"requireCanonical\":true}", RtBlockIdentifier)
+    let i = EthJson.decode("{\"blockHash\":\"" & $w & "\",\"requireCanonical\":true}", RtBlockIdentifier)
     check i.kind == bidHash
     check i.hash == w
     check i.requireCanonical == true
@@ -297,7 +297,7 @@ suite "JSON-RPC Quantity":
         check b == "\"0x16345785d8a0000\""
 
         let x = EthJson.decode("\"0xFFFF_FFFF_FFFF_FFFF\"", typeName)
-        check x.uint64 == 0xFFFF_FFFF_FFFF_FFFF_FFFF'u64
+        check x.uint64 == 0xFFFF_FFFF_FFFF_FFFF'u64
         let y = EthJson.encode(x)
         check y == "\"0xffffffffffffffff\""
 

--- a/tests/test_null_conversion.nim
+++ b/tests/test_null_conversion.nim
@@ -2,15 +2,14 @@ import
   std/[json, strutils],
   pkg/unittest2,
   stint,
-  json_rpc/jsonmarshal,
   ../web3/[conversions, eth_api_types, engine_api_types]
 
 template should_be_value_error(input: string, value: untyped): void =
   expect SerializationError:
-    value = JrpcConv.decode(input, typeof(value))
+    value = EthJson.decode(input, typeof(value))
 
 template should_not_error(input: string, value: untyped): void =
-  value = JrpcConv.decode(input, typeof(value))
+  value = EthJson.decode(input, typeof(value))
 
 suite "Null conversion":
   var resAddress: Address
@@ -68,8 +67,7 @@ suite "Null conversion":
 
   ## Covering the web3/engine_api_types
   ##
-  ## NOTE: These will be transformed by the JrpcConv imported from
-  ##       nim-json-rpc/json_rpc/jsonmarshal
+  ## NOTE: These will be transformed by EthJson
   test "passing nully values to specific convertors":
 
     let payloadAttributesV1 = """{ "timestamp": {item}, "prevRandao": {item}, "suggestedFeeRecipient": {item} }"""

--- a/web3.nim
+++ b/web3.nim
@@ -13,7 +13,7 @@ import
   std/[tables, uri, macros],
   httputils, chronos,
   results,
-  json_rpc/[jsonmarshal, router, rpcclient],
+  json_rpc/[router, rpcclient],
   json_rpc/private/jrpc_sys,
   eth/common/keys,
   chronos/apps/http/httpclient,
@@ -31,7 +31,8 @@ export
   contract_dsl,
   HttpClientFlag,
   HttpClientFlags,
-  eth_api
+  eth_api,
+  EthJson
 
 type
   Web3* = ref object
@@ -86,7 +87,7 @@ func getValue(
         when FieldType is JsonString:
           return ok(param.value)
         else:
-          let val = JrpcConv.decode(param.value.string, FieldType)
+          let val = EthJson.decode(param.value.string, FieldType)
           return ok(val)
   except CatchableError as exc:
     return err(exc.msg)
@@ -164,7 +165,7 @@ proc newWeb3*(
       await p.connect(uri)
 
       let w3 = newWeb3(p)
-      router[].rpc("eth_subscription") do(
+      router[].rpc("eth_subscription", EthJson) do(
         subscription: string, resultPar {.serializedFieldName: "result".}: JsonString
       ) -> void:
         w3.onSubscription(subscription, resultPar)
@@ -257,7 +258,7 @@ proc subscribeForBlockHeaders*(w: Web3,
   proc eventHandler(json: JsonString) {.gcsafe, raises: [].} =
 
     try:
-      let blk = JrpcConv.decode(json.string, BlockHeader)
+      let blk = EthJson.decode(json.string, BlockHeader)
       blockHeadersCallback(blk)
     except CatchableError as err:
       errorHandler(err[])

--- a/web3.nimble
+++ b/web3.nimble
@@ -20,15 +20,13 @@ requires "chronos"
 requires "bearssl"
 requires "eth >= 0.9.0"
 requires "faststreams"
-#requires "json_rpc >= 0.5.4"
+requires "json_rpc >= 0.6.0"
 requires "serialization >= 0.4.4"
 requires "json_serialization >= 0.4.2"
 requires "nimcrypto"
 requires "stew"
 requires "stint"
 requires "results"
-
-requires "https://github.com/status-im/nim-json-rpc#adfd20d8779112fe5f309d8d40c4b7da2ae5faec"
 
 ### Helper functions
 proc test(args, path: string) =

--- a/web3.nimble
+++ b/web3.nimble
@@ -20,13 +20,15 @@ requires "chronos"
 requires "bearssl"
 requires "eth >= 0.9.0"
 requires "faststreams"
-requires "json_rpc >= 0.5.4"
+#requires "json_rpc >= 0.5.4"
 requires "serialization >= 0.4.4"
 requires "json_serialization >= 0.4.2"
 requires "nimcrypto"
 requires "stew"
 requires "stint"
 requires "results"
+
+requires "https://github.com/nitely/nim-json-rpc#4e7faf1fccdbdd79fd7cdded7a80e86b60c09d18"
 
 ### Helper functions
 proc test(args, path: string) =

--- a/web3.nimble
+++ b/web3.nimble
@@ -28,7 +28,7 @@ requires "stew"
 requires "stint"
 requires "results"
 
-requires "https://github.com/nitely/nim-json-rpc#4e7faf1fccdbdd79fd7cdded7a80e86b60c09d18"
+requires "https://github.com/status-im/nim-json-rpc#adfd20d8779112fe5f309d8d40c4b7da2ae5faec"
 
 ### Helper functions
 proc test(args, path: string) =

--- a/web3/contract_dsl.nim
+++ b/web3/contract_dsl.nim
@@ -45,7 +45,7 @@ type
     data*: seq[byte]
     topics*: seq[Bytes32]
 
-EventData.useDefaultSerializationIn JrpcConv
+EventData.useDefaultSerializationIn EthJson
 
 proc joinStrings(s: varargs[string]): string = join(s)
 
@@ -251,7 +251,7 @@ proc genEvent(cname: NimNode, eventObject: EventObject): NimNode =
       callWithRawData = nnkCall.newTree(callbackIdent)
 
     argParseBody.add quote do:
-      let `eventData` = JrpcConv.decode(`jsonIdent`.string, EventData)
+      let `eventData` = EthJson.decode(`jsonIdent`.string, EventData)
 
     let tupleType = nnkTupleTy.newTree()
 

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -546,7 +546,7 @@ proc writeValue*(w: var JsonWriter[EthJson], v: TransactionArgs)
       w.writeMember(k, val)
   w.endObject()
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var StorageValuesRequest)
+proc readValue*(r: var JsonReader[EthJson], val: var StorageValuesRequest)
       {.gcsafe, raises: [IOError, SerializationError].} =
   mixin readValue
 
@@ -557,7 +557,7 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var StorageValuesRequest)
     readValue(r, value.data)
     val.list.add(move(value))
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: StorageValuesRequest)
+proc writeValue*(w: var JsonWriter[EthJson], v: StorageValuesRequest)
       {.gcsafe, raises: [IOError].} =
   mixin writeValue
   w.beginObject()

--- a/web3/conversions.nim
+++ b/web3/conversions.nim
@@ -13,12 +13,12 @@ import
   std/strutils,
   stew/byteutils,
   faststreams/textio,
-  json_rpc/jsonmarshal,
   json_serialization/pkg/results,
   json_serialization,
   ./primitives,
   ./engine_api_types,
   ./eth_api_types,
+  ./eth_json_marshal,
   ./execution_types
 
 import eth/common/eth_types_json_serialization
@@ -26,85 +26,85 @@ import eth/common/eth_types_json_serialization
 export
   results,
   json_serialization,
-  jsonmarshal
+  eth_json_marshal
 
 export eth_types_json_serialization except Topic
 
 #------------------------------------------------------------------------------
-# JrpcConv configuration
+# EthJson configuration
 #------------------------------------------------------------------------------
 
-JrpcConv.automaticSerialization(string, true)
-JrpcConv.automaticSerialization(JsonString, true)
-JrpcConv.automaticSerialization(ref, true)
-JrpcConv.automaticSerialization(seq, true)
-JrpcConv.automaticSerialization(bool, true)
-JrpcConv.automaticSerialization(float64, true)
-JrpcConv.automaticSerialization(array, true)
+EthJson.automaticSerialization(string, true)
+EthJson.automaticSerialization(JsonString, true)
+EthJson.automaticSerialization(ref, true)
+EthJson.automaticSerialization(seq, true)
+EthJson.automaticSerialization(bool, true)
+EthJson.automaticSerialization(float64, true)
+EthJson.automaticSerialization(array, true)
 
 #------------------------------------------------------------------------------
 # eth_api_types
 #------------------------------------------------------------------------------
 
-SyncObject.useDefaultSerializationIn JrpcConv
-Withdrawal.useDefaultSerializationIn JrpcConv
-AccessPair.useDefaultSerializationIn JrpcConv
-AccessListResult.useDefaultSerializationIn JrpcConv
-LogObject.useDefaultSerializationIn JrpcConv
-StorageProof.useDefaultSerializationIn JrpcConv
-ProofResponse.useDefaultSerializationIn JrpcConv
-FilterOptions.useDefaultSerializationIn JrpcConv
-TransactionArgs.useDefaultReaderIn JrpcConv
-FeeHistoryResult.useDefaultSerializationIn JrpcConv
-Authorization.useDefaultSerializationIn JrpcConv
+SyncObject.useDefaultSerializationIn EthJson
+Withdrawal.useDefaultSerializationIn EthJson
+AccessPair.useDefaultSerializationIn EthJson
+AccessListResult.useDefaultSerializationIn EthJson
+LogObject.useDefaultSerializationIn EthJson
+StorageProof.useDefaultSerializationIn EthJson
+ProofResponse.useDefaultSerializationIn EthJson
+FilterOptions.useDefaultSerializationIn EthJson
+TransactionArgs.useDefaultReaderIn EthJson
+FeeHistoryResult.useDefaultSerializationIn EthJson
+Authorization.useDefaultSerializationIn EthJson
 
-BlockHeader.useDefaultSerializationIn JrpcConv
-BlockObject.useDefaultSerializationIn JrpcConv
-TransactionObject.useDefaultSerializationIn JrpcConv
-ReceiptObject.useDefaultSerializationIn JrpcConv
-BlobScheduleObject.useDefaultSerializationIn JrpcConv
-ConfigObject.useDefaultSerializationIn JrpcConv
-EthConfigObject.useDefaultSerializationIn JrpcConv
+BlockHeader.useDefaultSerializationIn EthJson
+BlockObject.useDefaultSerializationIn EthJson
+TransactionObject.useDefaultSerializationIn EthJson
+ReceiptObject.useDefaultSerializationIn EthJson
+BlobScheduleObject.useDefaultSerializationIn EthJson
+ConfigObject.useDefaultSerializationIn EthJson
+EthConfigObject.useDefaultSerializationIn EthJson
 
 #------------------------------------------------------------------------------
 # engine_api_types
 #------------------------------------------------------------------------------
 
-WithdrawalV1.useDefaultSerializationIn JrpcConv
-ExecutionPayloadV1.useDefaultSerializationIn JrpcConv
-ExecutionPayloadV2.useDefaultSerializationIn JrpcConv
-ExecutionPayloadV1OrV2.useDefaultSerializationIn JrpcConv
-ExecutionPayloadV3.useDefaultSerializationIn JrpcConv
-ExecutionPayloadV4.useDefaultSerializationIn JrpcConv
-BlobsBundleV1.useDefaultSerializationIn JrpcConv
-BlobsBundleV2.useDefaultSerializationIn JrpcConv
-BlobAndProofV1.useDefaultSerializationIn JrpcConv
-BlobAndProofV2.useDefaultSerializationIn JrpcConv
-ExecutionPayloadBodyV1.useDefaultSerializationIn JrpcConv
-ExecutionPayloadBodyV2.useDefaultSerializationIn JrpcConv
-PayloadAttributesV1.useDefaultSerializationIn JrpcConv
-PayloadAttributesV2.useDefaultSerializationIn JrpcConv
-PayloadAttributesV3.useDefaultSerializationIn JrpcConv
-PayloadAttributesV4.useDefaultSerializationIn JrpcConv
-PayloadAttributesV1OrV2.useDefaultSerializationIn JrpcConv
-PayloadStatusV1.useDefaultSerializationIn JrpcConv
-ForkchoiceStateV1.useDefaultSerializationIn JrpcConv
-ForkchoiceUpdatedResponse.useDefaultSerializationIn JrpcConv
-GetPayloadV2Response.useDefaultSerializationIn JrpcConv
-GetPayloadV2ResponseExact.useDefaultSerializationIn JrpcConv
-GetPayloadV3Response.useDefaultSerializationIn JrpcConv
-GetPayloadV4Response.useDefaultSerializationIn JrpcConv
-GetPayloadV5Response.useDefaultSerializationIn JrpcConv
-GetPayloadV6Response.useDefaultSerializationIn JrpcConv
-ClientVersionV1.useDefaultSerializationIn JrpcConv
+WithdrawalV1.useDefaultSerializationIn EthJson
+ExecutionPayloadV1.useDefaultSerializationIn EthJson
+ExecutionPayloadV2.useDefaultSerializationIn EthJson
+ExecutionPayloadV1OrV2.useDefaultSerializationIn EthJson
+ExecutionPayloadV3.useDefaultSerializationIn EthJson
+ExecutionPayloadV4.useDefaultSerializationIn EthJson
+BlobsBundleV1.useDefaultSerializationIn EthJson
+BlobsBundleV2.useDefaultSerializationIn EthJson
+BlobAndProofV1.useDefaultSerializationIn EthJson
+BlobAndProofV2.useDefaultSerializationIn EthJson
+ExecutionPayloadBodyV1.useDefaultSerializationIn EthJson
+ExecutionPayloadBodyV2.useDefaultSerializationIn EthJson
+PayloadAttributesV1.useDefaultSerializationIn EthJson
+PayloadAttributesV2.useDefaultSerializationIn EthJson
+PayloadAttributesV3.useDefaultSerializationIn EthJson
+PayloadAttributesV4.useDefaultSerializationIn EthJson
+PayloadAttributesV1OrV2.useDefaultSerializationIn EthJson
+PayloadStatusV1.useDefaultSerializationIn EthJson
+ForkchoiceStateV1.useDefaultSerializationIn EthJson
+ForkchoiceUpdatedResponse.useDefaultSerializationIn EthJson
+GetPayloadV2Response.useDefaultSerializationIn EthJson
+GetPayloadV2ResponseExact.useDefaultSerializationIn EthJson
+GetPayloadV3Response.useDefaultSerializationIn EthJson
+GetPayloadV4Response.useDefaultSerializationIn EthJson
+GetPayloadV5Response.useDefaultSerializationIn EthJson
+GetPayloadV6Response.useDefaultSerializationIn EthJson
+ClientVersionV1.useDefaultSerializationIn EthJson
 
 #------------------------------------------------------------------------------
 # execution_types
 #------------------------------------------------------------------------------
 
-ExecutionPayload.useDefaultSerializationIn JrpcConv
-PayloadAttributes.useDefaultSerializationIn JrpcConv
-GetPayloadResponse.useDefaultSerializationIn JrpcConv
+ExecutionPayload.useDefaultSerializationIn EthJson
+PayloadAttributes.useDefaultSerializationIn EthJson
+GetPayloadResponse.useDefaultSerializationIn EthJson
 
 #------------------------------------------------------------------------------
 # Private helpers
@@ -218,21 +218,21 @@ proc writeHexValue(w: var JsonWriter, v: openArray[byte])
 # Well, both rpc and chronicles share the same encoding of these types
 #------------------------------------------------------------------------------
 
-type CommonJsonFlavors = JrpcConv | DefaultFlavor
+type CommonJsonFlavors = EthJson | DefaultFlavor
 
 proc writeValue*[F: CommonJsonFlavors](w: var JsonWriter[F], v: DynamicBytes)
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, distinctBase(v)
 
-proc writeValue*[N](w: var JsonWriter[JrpcConv], v: FixedBytes[N])
+proc writeValue*[N](w: var JsonWriter[EthJson], v: FixedBytes[N])
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, distinctBase(v)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: Address)
+proc writeValue*(w: var JsonWriter[EthJson], v: Address)
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, distinctBase(v)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: Hash32)
+proc writeValue*(w: var JsonWriter[EthJson], v: Hash32)
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, distinctBase(v)
 
@@ -257,17 +257,17 @@ proc readValue*[F: CommonJsonFlavors](r: var JsonReader[F], val: var DynamicByte
   wrapValueError:
     val = fromHex(DynamicBytes, r.parseString())
 
-proc readValue*[N](r: var JsonReader[JrpcConv], val: var FixedBytes[N])
+proc readValue*[N](r: var JsonReader[EthJson], val: var FixedBytes[N])
        {.gcsafe, raises: [IOError, JsonReaderError].} =
   wrapValueError:
     val = fromHex(FixedBytes[N], r.parseString())
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var Address)
+proc readValue*(r: var JsonReader[EthJson], val: var Address)
        {.gcsafe, raises: [IOError, JsonReaderError].} =
   wrapValueError:
     val = fromHex(Address, r.parseString())
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var Hash32)
+proc readValue*(r: var JsonReader[EthJson], val: var Hash32)
        {.gcsafe, raises: [IOError, JsonReaderError].} =
     let hexStr = r.parseString()
     if not valid(hexStr):
@@ -275,12 +275,12 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var Hash32)
     wrapValueError:
       val = fromHex(Hash32, hexStr)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: Number)
+proc writeValue*(w: var JsonWriter[EthJson], v: Number)
       {.gcsafe, raises: [IOError].} =
   w.streamElement(s):
     s.writeText distinctBase(v)
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var Number)
+proc readValue*(r: var JsonReader[EthJson], val: var Number)
        {.gcsafe, raises: [IOError, JsonReaderError].} =
   wrapValueError:
     val = r.parseInt(uint64).Number
@@ -357,17 +357,17 @@ proc readValue*[F: CommonJsonFlavors](r: var JsonReader[F], val: var seq[SystemC
     val.add SystemContractPair(name: k, address: v)
 
 #------------------------------------------------------------------------------
-# Exclusive to JrpcConv
+# Exclusive to EthJson
 #------------------------------------------------------------------------------
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: uint64 | uint8)
+proc writeValue*(w: var JsonWriter[EthJson], v: uint64 | uint8)
       {.gcsafe, raises: [IOError].} =
   w.streamElement(s):
     s.write "\"0x"
     s.toHex(v)
     s.write "\""
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var (uint8 | uint64))
+proc readValue*(r: var JsonReader[EthJson], val: var (uint8 | uint64))
        {.gcsafe, raises: [IOError, JsonReaderError].} =
   let hexStr = r.parseString()
   if hexStr.invalidQuantityPrefix:
@@ -375,11 +375,11 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var (uint8 | uint64))
   wrapValueError:
     val = strutils.fromHex[typeof(val)](hexStr)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: seq[byte])
+proc writeValue*(w: var JsonWriter[EthJson], v: seq[byte])
       {.gcsafe, raises: [IOError].} =
   writeHexValue w, v
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var seq[byte])
+proc readValue*(r: var JsonReader[EthJson], val: var seq[byte])
        {.gcsafe, raises: [IOError, JsonReaderError].} =
   wrapValueError:
     let hexStr = r.parseString()
@@ -387,7 +387,7 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var seq[byte])
       # skip empty hex
       val = hexToSeqByte(hexStr)
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var RtBlockIdentifier)
+proc readValue*(r: var JsonReader[EthJson], val: var RtBlockIdentifier)
        {.gcsafe, raises: [IOError, SerializationError].} =
   case r.tokKind
   of JsonValueKind.String:
@@ -429,27 +429,27 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var RtBlockIdentifier)
     r.raiseUnexpectedValue(
       "RtBlockIdentifier: string or object expected")
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: RtBlockIdentifier)
+proc writeValue*(w: var JsonWriter[EthJson], v: RtBlockIdentifier)
       {.gcsafe, raises: [IOError].} =
   case v.kind
   of bidNumber: w.writeValue(v.number)
   of bidAlias: w.writeValue(v.alias)
   of bidHash: w.writeValue(v.hash)
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var TxOrHash)
+proc readValue*(r: var JsonReader[EthJson], val: var TxOrHash)
        {.gcsafe, raises: [IOError, SerializationError].} =
   if r.tokKind == JsonValueKind.String:
     val = TxOrHash(kind: tohHash, hash: r.readValue(Hash32))
   else:
     val = TxOrHash(kind: tohTx, tx: r.readValue(TransactionObject))
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: TxOrHash)
+proc writeValue*(w: var JsonWriter[EthJson], v: TxOrHash)
       {.gcsafe, raises: [IOError].} =
   case v.kind
   of tohHash: w.writeValue(v.hash)
   of tohTx: w.writeValue(v.tx)
 
-proc readValue*[T](r: var JsonReader[JrpcConv], val: var SingleOrList[T])
+proc readValue*[T](r: var JsonReader[EthJson], val: var SingleOrList[T])
        {.gcsafe, raises: [IOError, SerializationError].} =
   let tok = r.tokKind()
   case tok
@@ -465,14 +465,14 @@ proc readValue*[T](r: var JsonReader[JrpcConv], val: var SingleOrList[T])
   else:
     r.raiseUnexpectedValue("TopicOrList unexpected token kind =" & $tok)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: SingleOrList)
+proc writeValue*(w: var JsonWriter[EthJson], v: SingleOrList)
       {.gcsafe, raises: [IOError].} =
   case v.kind
   of slkNull: w.writeValue(JsonString("null"))
   of slkSingle: w.writeValue(v.single)
   of slkList: w.writeValue(v.list)
 
-proc readValue*(r: var JsonReader[JrpcConv], val: var SyncingStatus)
+proc readValue*(r: var JsonReader[EthJson], val: var SyncingStatus)
        {.gcsafe, raises: [IOError, SerializationError].} =
   let tok = r.tokKind()
   case tok
@@ -484,7 +484,7 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var SyncingStatus)
   else:
     r.raiseUnexpectedValue("SyncingStatus unexpected token kind =" & $tok)
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: SyncingStatus)
+proc writeValue*(w: var JsonWriter[EthJson], v: SyncingStatus)
       {.gcsafe, raises: [IOError].} =
   if not v.syncing:
     w.writeValue(false)
@@ -492,7 +492,7 @@ proc writeValue*(w: var JsonWriter[JrpcConv], v: SyncingStatus)
     w.writeValue(v.syncObject)
 
 # Somehow nim2 refuse to generate automatically
-proc readValue*(r: var JsonReader[JrpcConv], val: var Opt[seq[ReceiptObject]])
+proc readValue*(r: var JsonReader[EthJson], val: var Opt[seq[ReceiptObject]])
        {.gcsafe, raises: [IOError, SerializationError].} =
   mixin readValue
 
@@ -502,7 +502,7 @@ proc readValue*(r: var JsonReader[JrpcConv], val: var Opt[seq[ReceiptObject]])
   else:
     val.ok r.readValue(seq[ReceiptObject])
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: Opt[seq[ReceiptObject]])
+proc writeValue*(w: var JsonWriter[EthJson], v: Opt[seq[ReceiptObject]])
       {.gcsafe, raises: [IOError].} =
   mixin writeValue
 
@@ -511,21 +511,21 @@ proc writeValue*(w: var JsonWriter[JrpcConv], v: Opt[seq[ReceiptObject]])
   else:
     w.writeValue JsonString("null")
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: seq[PrecompilePair])
+proc writeValue*(w: var JsonWriter[EthJson], v: seq[PrecompilePair])
       {.gcsafe, raises: [IOError].} =
   w.beginObject()
   for x in v:
     w.writeMember(x.name, x.address)
   w.endObject()
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: seq[SystemContractPair])
+proc writeValue*(w: var JsonWriter[EthJson], v: seq[SystemContractPair])
       {.gcsafe, raises: [IOError].} =
   w.beginObject()
   for x in v:
     w.writeMember(x.name, x.address)
   w.endObject()
 
-proc writeValue*(w: var JsonWriter[JrpcConv], v: TransactionArgs)
+proc writeValue*(w: var JsonWriter[EthJson], v: TransactionArgs)
       {.gcsafe, raises: [IOError].} =
   mixin writeValue
   var

--- a/web3/engine_api.nim
+++ b/web3/engine_api.nim
@@ -18,7 +18,7 @@ export
   conversions,
   execution_types
 
-createRpcSigsFromNim(RpcClient):
+createRpcSigsFromNim(RpcClient, EthJson):
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#methods
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#methods
   # https://github.com/ethereum/execution-apis/blob/ee3df5bc38f28ef35385cefc9d9ca18d5e502778/src/engine/cancun.md#methods

--- a/web3/eth_api.nim
+++ b/web3/eth_api.nim
@@ -10,7 +10,7 @@
 
 import
   std/json,
-  json_rpc/[client, jsonmarshal],
+  json_rpc/client,
   stint,
   ./conversions,
   ./eth_api_types
@@ -19,7 +19,7 @@ export
   eth_api_types,
   conversions
 
-createRpcSigsFromNim(RpcClient):
+createRpcSigsFromNim(RpcClient, EthJson):
   proc web3_clientVersion(): string
   proc web3_sha3(data: seq[byte]): Hash32
   proc net_version(): string
@@ -96,5 +96,5 @@ createRpcSigsFromNim(RpcClient):
   proc debug_getRawReceipts(blockId: BlockIdentifier): seq[RlpEncodedBytes]
   proc debug_getRawTransaction(data: Hash32): RlpEncodedBytes
 
-createSingleRpcSig(RpcClient, "eth_getJsonLogs"):
+createSingleRpcSig(RpcClient, "eth_getJsonLogs", EthJson):
   proc eth_getLogs(filterOptions: FilterOptions): seq[JsonString]

--- a/web3/eth_json_marshal.nim
+++ b/web3/eth_json_marshal.nim
@@ -1,0 +1,24 @@
+# nim-web3
+# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push gcsafe, raises: [].}
+
+import json_serialization
+
+export json_serialization
+
+createJsonFlavor EthJson,
+  automaticObjectSerialization = false,
+  requireAllFields = false,
+  omitOptionalFields = false, # Don't skip optional fields==none in Writer
+  allowUnknownFields = true,
+  skipNullFields = true,      # Skip optional fields==null in Reader
+  automaticPrimitivesSerialization = false
+
+EthJson.automaticSerialization(JsonNode, true)


### PR DESCRIPTION
Changes:

- Add `EthJson` (replaces `JrpcConv`).
- Add `web3/eth_json_marshal` (replaces `json_rpc/jsonmarshal`).
- Remove `JrpcConv` usage and `json_rpc/jsonmarshal` exports.
- Pending: nim-json-rpc release

Should `EthJson` live here or in nim-eth?

Note: `rpc` context adds an indentation level; if reviewing in github, turn on "Hide whitespace" config in the tool bar.