### PR TITLE
Bump execution-api tests + fix blockTimestamp in TX object

### DIFF
--- a/tests/test_execution_api.nim
+++ b/tests/test_execution_api.nim
@@ -170,6 +170,8 @@ const allowedToFail = [
   # Supports either the specific test file name or all tests for a specific method
   "fee-history.io", # float roundtrip not match
   "eth_simulateV1", # unimplemented
+  "eth_getStorageValues", # unimplemented
+  "testing_buildBlockV1", # unimplemented
 ]
 
 suite "Ethereum execution api":

--- a/web3/eth_api_types.nim
+++ b/web3/eth_api_types.nim
@@ -147,6 +147,7 @@ type
     nonce*: Quantity                              # the number of transactions made by the sender prior to this one.
     blockHash*: Opt[Hash32]                       # hash of the block where this transaction was in. null when its pending.
     blockNumber*: Opt[Quantity]                   # block number where this transaction was in. null when its pending.
+    blockTimestamp*: Opt[Quantity]                # the block timestamp where this transaction was in.
     transactionIndex*: Opt[Quantity]              # integer of the transactions index position in the block. null when its pending.
     `from`*: Address                              # address of the sender.
     to*: Opt[Address]                             # address of the receiver. null when its a contract creation transaction.


### PR DESCRIPTION
blockTimestamp got added in the transaction object:
- https://github.com/ethereum/execution-apis/pull/749

Need to disable tests for two new and currently not implemented json-rpc methods:

- eth_getStorageValues
- testing_buildBlockV1