### PR TITLE
add targetGasLimit to engine API PayloadAttributesV4

### DIFF
--- a/tests/test_json_marshalling.nim
+++ b/tests/test_json_marshalling.nim
@@ -218,6 +218,7 @@ suite "JSON-RPC Quantity":
     checkRandomObject(PayloadAttributesV1)
     checkRandomObject(PayloadAttributesV2)
     checkRandomObject(PayloadAttributesV3)
+    checkRandomObject(PayloadAttributesV4)
     checkRandomObject(PayloadAttributesV1OrV2)
     checkRandomObject(PayloadStatusV1)
     checkRandomObject(ForkchoiceStateV1)

--- a/web3/engine_api_types.nim
+++ b/web3/engine_api_types.nim
@@ -206,7 +206,7 @@ type
     withdrawals*: seq[WithdrawalV1]
     parentBeaconBlockRoot*: Hash32
 
-  # https://github.com/ethereum/execution-apis/blob/dc4dbca37ef8697d782f431af19120beaf5517f5/src/engine/amsterdam.md#payloadattributesv4
+  # https://github.com/ethereum/execution-apis/blob/a22fbd4464ef77404935a056f9e19db0abb359a1/src/engine/amsterdam.md#payloadattributesv4
   PayloadAttributesV4* = object
     timestamp*: Quantity
     prevRandao*: Bytes32
@@ -214,6 +214,7 @@ type
     withdrawals*: seq[WithdrawalV1]
     parentBeaconBlockRoot*: Hash32
     slotNumber*: Quantity
+    targetGasLimit*: Quantity
 
   # This is ugly, but see the comment on ExecutionPayloadV1OrV2.
   PayloadAttributesV1OrV2* = object

--- a/web3/execution_types.nim
+++ b/web3/execution_types.nim
@@ -46,6 +46,7 @@ type
     withdrawals*: Opt[seq[WithdrawalV1]]
     parentBeaconBlockRoot*: Opt[Hash32]
     slotNumber*: Opt[Quantity]
+    targetGasLimit*: Opt[Quantity]
 
   SomeOptionalPayloadAttributes* =
     Opt[PayloadAttributesV1] |
@@ -80,7 +81,7 @@ func version*(payload: ExecutionPayload): Version =
     Version.V1
 
 func version*(attr: PayloadAttributes): Version =
-  if attr.slotNumber.isSome:
+  if attr.slotNumber.isSome or attr.targetGasLimit.isSome:
     Version.V4
   elif attr.parentBeaconBlockRoot.isSome:
     Version.V3
@@ -143,7 +144,8 @@ func V4*(attr: PayloadAttributes): PayloadAttributesV4 =
     suggestedFeeRecipient: attr.suggestedFeeRecipient,
     withdrawals: attr.withdrawals.get(newSeq[WithdrawalV1]()),
     parentBeaconBlockRoot: attr.parentBeaconBlockRoot.get,
-    slotNumber: attr.slotNumber.get
+    slotNumber: attr.slotNumber.get,
+    targetGasLimit: attr.targetGasLimit.get
   )
 
 func V1*(attr: Opt[PayloadAttributes]): Opt[PayloadAttributesV1] =
@@ -197,7 +199,8 @@ func payloadAttributes*(attr: PayloadAttributesV4): PayloadAttributes =
     suggestedFeeRecipient: attr.suggestedFeeRecipient,
     withdrawals: Opt.some(attr.withdrawals),
     parentBeaconBlockRoot: Opt.some(attr.parentBeaconBlockRoot),
-    slotNumber: Opt.some(attr.slotNumber)
+    slotNumber: Opt.some(attr.slotNumber),
+    targetGasLimit: Opt.some(attr.targetGasLimit)
   )
 
 func payloadAttributes*(x: Opt[PayloadAttributesV1]): Opt[PayloadAttributes] =


### PR DESCRIPTION
Required for [glamsterdam-devnet-4](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-4):
- https://github.com/ethereum/execution-apis/pull/796